### PR TITLE
Account for change in pipeline download task path

### DIFF
--- a/.azure-pipelines/client.yml
+++ b/.azure-pipelines/client.yml
@@ -69,7 +69,7 @@ jobs:
           PythonVersion: '$(PythonVersion38)'
 
     variables:
-      OpenSSLDir: $(Agent.BuildDirectory)/openssl
+      OpenSSLDir: $(Agent.BuildDirectory)/openssl-macosx$(MacOSXDeploymentTarget)
       PythonVersion27: '2.7.15'
       PythonVersion35: '3.5.4'
       PythonVersion36: '3.6.5'
@@ -82,7 +82,7 @@ jobs:
           artifactName: openssl-macosx$(MacOSXDeploymentTarget)
           buildType: specific
           buildVersionToDownload: latest
-          downloadPath: $(OpenSSLDir)
+          downloadPath: $(Agent.BuildDirectory)
           pipeline: 119 # azure-uamqp-python - openssl
           project: '29ec6040-b234-4e31-b139-33dc4287b756' # public
 


### PR DESCRIPTION
Azure DevOps appears to have changed how it handles destination paths
when using DownloadPipelineArtifact.