### PR TITLE
Share CBS Session

### DIFF
--- a/samples/asynctests/test_azure_event_hubs_receive_async.py
+++ b/samples/asynctests/test_azure_event_hubs_receive_async.py
@@ -131,7 +131,6 @@ async def test_event_hubs_batch_receive_async(live_eventhub_config):
 
 @pytest.mark.asyncio
 async def test_event_hubs_shared_connection_async(live_eventhub_config):
-    pytest.skip("Unstable on OSX and Linux - need to fix")  # TODO
     uri = "sb://{}/{}".format(live_eventhub_config['hostname'], live_eventhub_config['event_hub'])
     sas_auth = authentication.SASTokenAsync.from_shared_access_key(
         uri, live_eventhub_config['key_name'], live_eventhub_config['access_key'])
@@ -172,7 +171,6 @@ async def receive_ten(partition, receiver):
 
 @pytest.mark.asyncio
 async def test_event_hubs_multiple_receiver_async(live_eventhub_config):
-    pytest.skip("Unstable on OSX and Linux - need to fix")  # TODO
     uri = "sb://{}/{}".format(live_eventhub_config['hostname'], live_eventhub_config['event_hub'])
     sas_auth_a = authentication.SASTokenAsync.from_shared_access_key(
         uri, live_eventhub_config['key_name'], live_eventhub_config['access_key'])

--- a/samples/asynctests/test_azure_event_hubs_receive_async.py
+++ b/samples/asynctests/test_azure_event_hubs_receive_async.py
@@ -45,7 +45,7 @@ async def test_event_hubs_callback_async_receive(live_eventhub_config):
         live_eventhub_config['consumer_group'],
         live_eventhub_config['partition'])
 
-    receive_client = uamqp.ReceiveClientAsync(source, auth=sas_auth, timeout=10, prefetch=10)
+    receive_client = uamqp.ReceiveClientAsync(source, auth=sas_auth, timeout=1000, prefetch=10)
     log.info("Created client, receiving...")
     await receive_client.receive_messages_async(on_message_received)
     log.info("Finished receiving")
@@ -65,7 +65,7 @@ async def test_event_hubs_filter_receive_async(live_eventhub_config):
     source = address.Source(source_url)
     source.set_filter(b"amqp.annotation.x-opt-enqueuedtimeutc > 1518731960545")
 
-    receive_client = uamqp.ReceiveClientAsync(source, auth=plain_auth, timeout=50)
+    receive_client = uamqp.ReceiveClientAsync(source, auth=plain_auth, timeout=5000)
     await receive_client.receive_messages_async(on_message_received)
 
 

--- a/samples/asynctests/test_azure_event_hubs_receive_async.py
+++ b/samples/asynctests/test_azure_event_hubs_receive_async.py
@@ -80,7 +80,7 @@ async def test_event_hubs_iter_receive_async(live_eventhub_config):
         live_eventhub_config['consumer_group'],
         live_eventhub_config['partition'])
 
-    receive_client = uamqp.ReceiveClientAsync(source, debug=False, auth=sas_auth, timeout=1000, prefetch=10)
+    receive_client = uamqp.ReceiveClientAsync(source, debug=False, auth=sas_auth, timeout=3000, prefetch=10)
     count = 0
     message_generator = receive_client.receive_messages_iter_async()
     async for message in message_generator:
@@ -111,7 +111,7 @@ async def test_event_hubs_batch_receive_async(live_eventhub_config):
         live_eventhub_config['consumer_group'],
         live_eventhub_config['partition'])
 
-    async with uamqp.ReceiveClientAsync(source, debug=False, auth=sas_auth, timeout=1000, prefetch=10) as receive_client:
+    async with uamqp.ReceiveClientAsync(source, debug=False, auth=sas_auth, timeout=3000, prefetch=10) as receive_client:
         message_batch = await receive_client.receive_message_batch_async(10)
         log.info("got batch: {}".format(len(message_batch)))
         for message in message_batch:
@@ -140,8 +140,8 @@ async def test_event_hubs_shared_connection_async(live_eventhub_config):
         live_eventhub_config['consumer_group'])
 
     async with uamqp.ConnectionAsync(live_eventhub_config['hostname'], sas_auth, debug=False) as conn:
-        partition_0 = uamqp.ReceiveClientAsync(source + "0", debug=False, auth=sas_auth, timeout=1000, prefetch=10)
-        partition_1 = uamqp.ReceiveClientAsync(source + "1", debug=False, auth=sas_auth, timeout=1000, prefetch=10)
+        partition_0 = uamqp.ReceiveClientAsync(source + "0", debug=False, auth=sas_auth, timeout=3000, prefetch=10)
+        partition_1 = uamqp.ReceiveClientAsync(source + "1", debug=False, auth=sas_auth, timeout=3000, prefetch=10)
         await partition_0.open_async(connection=conn)
         await partition_1.open_async(connection=conn)
         tasks = [
@@ -181,8 +181,8 @@ async def test_event_hubs_multiple_receiver_async(live_eventhub_config):
         live_eventhub_config['event_hub'],
         live_eventhub_config['consumer_group'])
 
-    partition_0 = uamqp.ReceiveClientAsync(source + "0", debug=False, auth=sas_auth_a, timeout=1000, prefetch=10)
-    partition_1 = uamqp.ReceiveClientAsync(source + "1", debug=False, auth=sas_auth_b, timeout=1000, prefetch=10)
+    partition_0 = uamqp.ReceiveClientAsync(source + "0", debug=False, auth=sas_auth_a, timeout=3000, prefetch=10)
+    partition_1 = uamqp.ReceiveClientAsync(source + "1", debug=False, auth=sas_auth_b, timeout=3000, prefetch=10)
     try:
         await partition_0.open_async()
         await partition_1.open_async()

--- a/samples/test_azure_iothub_receive2.py
+++ b/samples/test_azure_iothub_receive2.py
@@ -60,7 +60,7 @@ def _build_iothub_amqp_endpoint_from_target(target):
 
 def _receive_message(conn, source, auth):
     batch = []
-    receive_client = uamqp.ReceiveClient(source, auth=auth, debug=False, timeout=5, prefetch=50)
+    receive_client = uamqp.ReceiveClient(source, auth=auth, debug=False, timeout=5000, prefetch=50)
     try:
         receive_client.open(connection=conn)
         batch = receive_client.receive_message_batch(max_batch_size=10)

--- a/uamqp/async_ops/client_async.py
+++ b/uamqp/async_ops/client_async.py
@@ -13,7 +13,7 @@ import logging
 import queue
 import uuid
 
-from uamqp import address, authentication, client, constants, errors
+from uamqp import address, authentication, client, constants, errors, compat
 from uamqp.utils import get_running_loop
 from uamqp.async_ops.connection_async import ConnectionAsync
 from uamqp.async_ops.receiver_async import MessageReceiverAsync

--- a/uamqp/async_ops/client_async.py
+++ b/uamqp/async_ops/client_async.py
@@ -906,7 +906,6 @@ class ReceiveClientAsync(client.ReceiveClient, AMQPClientAsync):
                 'connection link credit: {}'.format(max_batch_size, self._prefetch))
         timeout = self._counter.get_current_ms() + int(timeout) if timeout else 0
         expired = False
-        self._received_messages = self._received_messages or queue.Queue()
         await self.open_async()
         receiving = True
         batch = []
@@ -950,7 +949,6 @@ class ReceiveClientAsync(client.ReceiveClient, AMQPClientAsync):
         :rtype: Generator[~uamqp.message.Message]
         """
         self._message_received_callback = on_message_received
-        self._received_messages = self._received_messages or compat.queue.Queue()
         return AsyncMessageIter(self, auto_complete=self.auto_complete)
 
     async def redirect_async(self, redirect, auth):

--- a/uamqp/async_ops/client_async.py
+++ b/uamqp/async_ops/client_async.py
@@ -860,7 +860,7 @@ class ReceiveClientAsync(client.ReceiveClient, AMQPClientAsync):
          service. It takes a single argument, a ~uamqp.message.Message object.
         :type on_message_received: callable[~uamqp.message.Message]
         """
-        self.streaming_receive = True
+        self._streaming_receive = True
         await self.open_async()
         self._message_received_callback = on_message_received
         receiving = True
@@ -871,7 +871,7 @@ class ReceiveClientAsync(client.ReceiveClient, AMQPClientAsync):
             receiving = False
             raise
         finally:
-            self.streaming_receive = False
+            self._streaming_receive = False
             if not receiving:
                 await self.close_async()
 
@@ -951,8 +951,6 @@ class ReceiveClientAsync(client.ReceiveClient, AMQPClientAsync):
         """
         self._message_received_callback = on_message_received
         self._received_messages = self._received_messages or compat.queue.Queue()
-        # previsouly new Queue every time
-        # why? what about the recevied unhandled messages, they will be simply dropped
         return AsyncMessageIter(self, auto_complete=self.auto_complete)
 
     async def redirect_async(self, redirect, auth):

--- a/uamqp/async_ops/client_async.py
+++ b/uamqp/async_ops/client_async.py
@@ -258,7 +258,7 @@ class AMQPClientAsync(client.AMQPClient):
         if self._keep_alive_interval:
             self._keep_alive_thread = asyncio.ensure_future(self._keep_alive_async(), loop=self.loop)
         if self._ext_connection:
-            await connection.release_async()
+            connection.release_async()
 
     async def close_async(self):
         """Close the client asynchronously. This includes closing the Session

--- a/uamqp/async_ops/client_async.py
+++ b/uamqp/async_ops/client_async.py
@@ -945,7 +945,9 @@ class ReceiveClientAsync(client.ReceiveClient, AMQPClientAsync):
         :rtype: Generator[~uamqp.message.Message]
         """
         self._message_received_callback = on_message_received
-        self._received_messages = queue.Queue()
+        self._received_messages = self._received_messages or compat.queue.Queue()
+        # previsouly new Queue every time
+        # why? what about the recevied unhandled messages, they will be simply dropped
         return AsyncMessageIter(self, auto_complete=self.auto_complete)
 
     async def redirect_async(self, redirect, auth):
@@ -967,6 +969,7 @@ class ReceiveClientAsync(client.ReceiveClient, AMQPClientAsync):
         self._shutdown = False
         self._last_activity_timestamp = None
         self._was_message_received = False
+        self._received_messages = compat.queue.Queue()
 
         self._remote_address = address.Source(redirect.address)
         await self._redirect_async(redirect, auth)

--- a/uamqp/async_ops/client_async.py
+++ b/uamqp/async_ops/client_async.py
@@ -10,7 +10,6 @@
 import asyncio
 import collections.abc
 import logging
-import queue
 import uuid
 
 from uamqp import address, authentication, client, constants, errors, compat

--- a/uamqp/client.py
+++ b/uamqp/client.py
@@ -871,7 +871,10 @@ class ReceiveClient(AMQPClient):
         self._last_activity_timestamp = None
         self._was_message_received = False
         self._message_received_callback = None
-        self._received_messages = None
+        # TODO: would it be breaking to change from None to an empty Object, why previously set to None
+        # to make the _received_messages not a none object, think about the case when it should be initialized None
+        # maybe can use .empty to have the same effect
+        self._received_messages = compat.queue.Queue()
 
         # Receiver and Link settings
         self._max_message_size = kwargs.pop('max_message_size', None) or constants.MAX_MESSAGE_LENGTH_BYTES
@@ -1097,7 +1100,9 @@ class ReceiveClient(AMQPClient):
         :type on_message_received: callable[~uamqp.message.Message]
         """
         self._message_received_callback = on_message_received
-        self._received_messages = compat.queue.Queue()
+        self._received_messages = self._received_messages or compat.queue.Queue()
+        # previsouly new Queue every time
+        # why? what about the recevied unhandled messages, they will be simply dropped
         return self._message_generator()
 
     def redirect(self, redirect, auth):
@@ -1119,7 +1124,7 @@ class ReceiveClient(AMQPClient):
         self._shutdown = False
         self._last_activity_timestamp = None
         self._was_message_received = False
-        self._received_messages = None
+        self._received_messages = compat.queue.Queue()
 
         self._remote_address = address.Source(redirect.address)
         self._redirect(redirect, auth)

--- a/uamqp/client.py
+++ b/uamqp/client.py
@@ -1036,7 +1036,6 @@ class ReceiveClient(AMQPClient):
                 'connection link credit: {}'.format(self._prefetch))
         timeout = self._counter.get_current_ms() + timeout if timeout else 0
         expired = False
-        self._received_messages = self._received_messages or compat.queue.Queue()
         self.open()
         receiving = True
         batch = []
@@ -1102,7 +1101,6 @@ class ReceiveClient(AMQPClient):
         :type on_message_received: callable[~uamqp.message.Message]
         """
         self._message_received_callback = on_message_received
-        self._received_messages = self._received_messages or compat.queue.Queue()
         return self._message_generator()
 
     def redirect(self, redirect, auth):


### PR DESCRIPTION
Initialize the `_received_messages` when in the `__init__` function of the AMQP client so that received messages won't be simply dropped during the authentication process of multiple clients.

-----

@annatisch 
I'm wondering whether the `self._streaming_receive` should be thread-safe or not.

The situation where thread-unsafe may happen to the `_streaming_receive` variable is that both functions `receive_message_batch` and `receive_messages` are called simultaneously.

But I don't think our SDK support such kind of operation, do I miss something?