### PR TITLE
Fix websocket support.

### DIFF
--- a/uamqp/authentication/common.py
+++ b/uamqp/authentication/common.py
@@ -66,7 +66,7 @@ class AMQPAuth(object):
         return value.encode(self._encoding) if isinstance(value, six.text_type) else value
 
     def set_io(self, hostname, port, http_proxy, transport_type):
-        if transport_type == TransportType.AmqpOverWebsocket:
+        if transport_type == TransportType.AmqpOverWebsocket or http_proxy is not None:
             self.set_wsio(hostname, constants.DEFAULT_AMQP_WSS_PORT, http_proxy)
         else:
             self.set_tlsio(hostname, port)


### PR DESCRIPTION
amqp over Websocket does not work when only http_proxy is defined.

The documentation states of the AMQPAuth class states that when http_proxy is defined the transport_type is implicitly set to uamqp.TransportType.AmqpOverWebsocket. This was not the case... 
