### PR TITLE
Fix missing cimport c_amqp_definitions

### DIFF
--- a/src/connection.pyx
+++ b/src/connection.pyx
@@ -10,6 +10,7 @@ from enum import Enum
 
 # C imports
 from libc cimport stdint
+cimport c_amqp_definitions
 cimport c_connection
 cimport c_xio
 


### PR DESCRIPTION
Otherwise:
```
[1/1] Cythonizing uamqp/c_uamqp.pyx

Error compiling Cython file:
------------------------------------------------------------
...
            return _value
        else:
            self._value_error()

    @idle_timeout.setter
    def idle_timeout(self, c_amqp_definitions.milliseconds value):
                          ^
------------------------------------------------------------

./src/connection.pyx:149:27: 'c_amqp_definitions' is not declared

Error compiling Cython file:
------------------------------------------------------------
...
        context_obj = <object>context
        if hasattr(context_obj, '_io_error'):
            context_obj._io_error()


cdef void on_connection_close_received(void* context, c_amqp_definitions.ERROR_HANDLE error):
                                                     ^
------------------------------------------------------------

./src/connection.pyx:197:54: 'c_amqp_definitions' is not declared
Traceback (most recent call last):
  File "./setup.py", line 318, in <module>
    extensions = cythonize(extensions)
  File "/azure-uamqp-python/env/lib/python3.6/site-packages/Cython/Build/Dependencies.py", line 1026, in cythonize
    cythonize_one(*args)
  File "/azure-uamqp-python/env/lib/python3.6/site-packages/Cython/Build/Dependencies.py", line 1146, in cythonize_one
    raise CompileError(None, pyx_file)
Cython.Compiler.Errors.CompileError: uamqp/c_uamqp.pyx
```