### PR TITLE
Update type of current_link_credit from uint_32 to int_32

### DIFF
--- a/src/vendor/azure-uamqp-c/src/link.c
+++ b/src/vendor/azure-uamqp-c/src/link.c
@@ -57,7 +57,7 @@ typedef struct LINK_INSTANCE_TAG
     sequence_no initial_delivery_count;
     uint64_t max_message_size;
     uint64_t peer_max_message_size;
-    uint32_t current_link_credit;
+    int32_t current_link_credit;
     uint32_t max_link_credit;
     uint32_t available;
     fields attach_properties;


### PR DESCRIPTION
Update type of current_link_credit from uint_32 to int_32.

current_link_credit won't be < 0 as it's type of unsigned int which makes the `send_flow` in link.do_work can't work as expected when receiving large message which consumes multiple link credit at a one.

After making it type of int_32, it can become negative.