### PR TITLE
Support for connection desired capabilities

### DIFF
--- a/src/connection.pyx
+++ b/src/connection.pyx
@@ -171,6 +171,21 @@ cdef class Connection(StructBase):
             self._value_error()
 
     @property
+    def desired_capabilities(self):
+        cdef c_amqpvalue.AMQP_VALUE _value
+        if c_connection.connection_get_desired_capabilities(self._c_value, &_value) == 0:
+            if <void*>_value == NULL:
+                return None
+            return value_factory(_value)
+        else:
+            self._value_error()
+
+    @desired_capabilities.setter
+    def desired_capabilities(self, AMQPValue value):
+        if c_connection.connection_set_desired_capabilities(self._c_value, <c_amqpvalue.AMQP_VALUE>value._c_value) != 0:
+            self._value_error()
+
+    @property
     def remote_max_frame_size(self):
         cdef stdint.uint32_t _value
         if c_connection.connection_get_remote_max_frame_size(self._c_value, &_value) == 0:

--- a/src/vendor/azure-uamqp-c/inc/azure_uamqp_c/connection.h
+++ b/src/vendor/azure-uamqp-c/inc/azure_uamqp_c/connection.h
@@ -90,6 +90,8 @@ extern "C" {
     MOCKABLE_FUNCTION(, int, connection_get_idle_timeout, CONNECTION_HANDLE, connection, milliseconds*, idle_timeout);
     MOCKABLE_FUNCTION(, int, connection_set_properties, CONNECTION_HANDLE, connection, fields, properties);
     MOCKABLE_FUNCTION(, int, connection_get_properties, CONNECTION_HANDLE, connection, fields*, properties);
+    MOCKABLE_FUNCTION(, int, connection_set_desired_capabilities, CONNECTION_HANDLE, connection, AMQP_VALUE, desired_capabilities);
+    MOCKABLE_FUNCTION(, int, connection_get_desired_capabilities, CONNECTION_HANDLE, connection, AMQP_VALUE*, desired_capabilities);
     MOCKABLE_FUNCTION(, int, connection_get_remote_max_frame_size, CONNECTION_HANDLE, connection, uint32_t*, remote_max_frame_size);
     MOCKABLE_FUNCTION(, int, connection_set_remote_idle_timeout_empty_frame_send_ratio, CONNECTION_HANDLE, connection, double, idle_timeout_empty_frame_send_ratio);
     MOCKABLE_FUNCTION(, uint64_t, connection_handle_deadlines, CONNECTION_HANDLE, connection);

--- a/src/vendor/inc/c_connection.pxd
+++ b/src/vendor/inc/c_connection.pxd
@@ -56,6 +56,8 @@ cdef extern from "azure_uamqp_c/connection.h":
     int connection_get_idle_timeout(CONNECTION_HANDLE connection, c_amqp_definitions.milliseconds* idle_timeout)
     int connection_set_properties(CONNECTION_HANDLE connection, c_amqp_definitions.fields properties)
     int connection_get_properties(CONNECTION_HANDLE connection, c_amqp_definitions.fields* properties)
+    int connection_set_desired_capabilities(CONNECTION_HANDLE connection, c_amqpvalue.AMQP_VALUE desired_capabilities)
+    int connection_get_desired_capabilities(CONNECTION_HANDLE connection, c_amqpvalue.AMQP_VALUE* desired_capabilities)
     int connection_get_remote_max_frame_size(CONNECTION_HANDLE connection, stdint.uint32_t* remote_max_frame_size)
     int connection_set_remote_idle_timeout_empty_frame_send_ratio(CONNECTION_HANDLE connection, double idle_timeout_empty_frame_send_ratio)
     stdint.uint64_t connection_handle_deadlines(CONNECTION_HANDLE connection)

--- a/uamqp/async_ops/client_async.py
+++ b/uamqp/async_ops/client_async.py
@@ -65,12 +65,14 @@ class AMQPClientAsync(client.AMQPClient):
     :type idle_timeout: int
     :param properties: Connection properties.
     :type properties: dict
-    :param desired_capabilities: The extension capabilities desired from the peer endpoint to be sent in the link ATTACH frame.
+    :param desired_capabilities: The extension capabilities desired from the peer
+     endpoint to be sent in the link ATTACH frame.
      To create an desired_capabilities object, please do as follows:
         - 1. Create an array of desired capability symbols: `capabilities_symbol_array = [types.AMQPSymbol(string)]`
         - 2. Transform the array to AMQPValue object: `utils.data_factory(types.AMQPArray(capabilities_symbol_array))`
     :type desired_capabilities: ~uamqp.c_uamqp.AMQPValue
-    :param connection_desired_capabilities: The extension capabilities desired from the peer endpoint to be sent in the connection OPEN frame.
+    :param connection_desired_capabilities: The extension capabilities desired from the
+     peer endpoint to be sent in the connection OPEN frame.
      To create a desired_capabilities object, please do as follows:
         - 1. Create an array of desired capability symbols: `capabilities_symbol_array = [types.AMQPSymbol(string)]`
         - 2. Transform the array to AMQPValue object: `utils.data_factory(types.AMQPArray(capabilities_symbol_array))`

--- a/uamqp/async_ops/client_async.py
+++ b/uamqp/async_ops/client_async.py
@@ -65,6 +65,16 @@ class AMQPClientAsync(client.AMQPClient):
     :type idle_timeout: int
     :param properties: Connection properties.
     :type properties: dict
+    :param desired_capabilities: The extension capabilities desired from the peer endpoint to be sent in the link ATTACH frame.
+     To create an desired_capabilities object, please do as follows:
+        - 1. Create an array of desired capability symbols: `capabilities_symbol_array = [types.AMQPSymbol(string)]`
+        - 2. Transform the array to AMQPValue object: `utils.data_factory(types.AMQPArray(capabilities_symbol_array))`
+    :type desired_capabilities: ~uamqp.c_uamqp.AMQPValue
+    :param connection_desired_capabilities: The extension capabilities desired from the peer endpoint to be sent in the connection OPEN frame.
+     To create a desired_capabilities object, please do as follows:
+        - 1. Create an array of desired capability symbols: `capabilities_symbol_array = [types.AMQPSymbol(string)]`
+        - 2. Transform the array to AMQPValue object: `utils.data_factory(types.AMQPArray(capabilities_symbol_array))`
+    :type connection_desired_capabilities: ~uamqp.c_uamqp.AMQPValue
     :param remote_idle_timeout_empty_frame_send_ratio: Ratio of empty frames to
      idle time for Connections with no activity. Value must be between
      0.0 and 1.0 inclusive. Default is 0.5.
@@ -718,11 +728,6 @@ class ReceiveClientAsync(client.ReceiveClient, AMQPClientAsync):
      will assume successful receipt of the message and clear it from the queue. The
      default is `PeekLock`.
     :type receive_settle_mode: ~uamqp.constants.ReceiverSettleMode
-    :param desired_capabilities: The extension capabilities desired from the peer endpoint.
-     To create an desired_capabilities object, please do as follows:
-        - 1. Create an array of desired capability symbols: `capabilities_symbol_array = [types.AMQPSymbol(string)]`
-        - 2. Transform the array to AMQPValue object: `utils.data_factory(types.AMQPArray(capabilities_symbol_array))`
-    :type desired_capabilities: ~uamqp.c_uamqp.AMQPValue
     :param max_message_size: The maximum allowed message size negotiated for the Link.
     :type max_message_size: int
     :param link_properties: Metadata to be sent in the Link ATTACH frame.

--- a/uamqp/async_ops/connection_async.py
+++ b/uamqp/async_ops/connection_async.py
@@ -46,6 +46,11 @@ class ConnectionAsync(connection.Connection):
     :type idle_timeout: int
     :param properties: Connection properties.
     :type properties: dict
+    :param desired_capabilities: The extension capabilities desired from the peer endpoint to be sent in the connection OPEN frame.
+     To create a desired_capabilities object, please do as follows:
+        - 1. Create an array of desired capability symbols: `capabilities_symbol_array = [types.AMQPSymbol(string)]`
+        - 2. Transform the array to AMQPValue object: `utils.data_factory(types.AMQPArray(capabilities_symbol_array))`
+    :type desired_capabilities: ~uamqp.c_uamqp.AMQPValue
     :param remote_idle_timeout_empty_frame_send_ratio: Ratio of empty frames to
      idle time for Connections with no activity. Value must be between
      0.0 and 1.0 inclusive. Default is 0.5.
@@ -66,6 +71,7 @@ class ConnectionAsync(connection.Connection):
                  channel_max=None,
                  idle_timeout=None,
                  properties=None,
+                 desired_capabilities=None,
                  remote_idle_timeout_empty_frame_send_ratio=None,
                  error_policy=None,
                  debug=False,
@@ -79,6 +85,7 @@ class ConnectionAsync(connection.Connection):
             channel_max=channel_max,
             idle_timeout=idle_timeout,
             properties=properties,
+            desired_capabilities=desired_capabilities,
             remote_idle_timeout_empty_frame_send_ratio=remote_idle_timeout_empty_frame_send_ratio,
             error_policy=error_policy,
             debug=debug,

--- a/uamqp/async_ops/connection_async.py
+++ b/uamqp/async_ops/connection_async.py
@@ -46,7 +46,8 @@ class ConnectionAsync(connection.Connection):
     :type idle_timeout: int
     :param properties: Connection properties.
     :type properties: dict
-    :param desired_capabilities: The extension capabilities desired from the peer endpoint to be sent in the connection OPEN frame.
+    :param desired_capabilities: The extension capabilities desired from the peer
+     endpoint to be sent in the connection OPEN frame.
      To create a desired_capabilities object, please do as follows:
         - 1. Create an array of desired capability symbols: `capabilities_symbol_array = [types.AMQPSymbol(string)]`
         - 2. Transform the array to AMQPValue object: `utils.data_factory(types.AMQPArray(capabilities_symbol_array))`

--- a/uamqp/async_ops/receiver_async.py
+++ b/uamqp/async_ops/receiver_async.py
@@ -50,7 +50,8 @@ class MessageReceiverAsync(receiver.MessageReceiver):
      from the service that the message was successfully sent. If set to 'Settled',
      the client will not wait for confirmation and assume success.
     :type send_settle_mode: ~uamqp.constants.SenderSettleMode
-    :param desired_capabilities: The extension capabilities desired from the peer endpoint to be sent in the link ATTACH frame.
+    :param desired_capabilities: The extension capabilities desired from the peer
+     endpoint to be sent in the link ATTACH frame.
      To create a desired_capabilities object, please do as follows:
         - 1. Create an array of desired capability symbols: `capabilities_symbol_array = [types.AMQPSymbol(string)]`
         - 2. Transform the array to AMQPValue object: `utils.data_factory(types.AMQPArray(capabilities_symbol_array))`

--- a/uamqp/async_ops/receiver_async.py
+++ b/uamqp/async_ops/receiver_async.py
@@ -50,8 +50,8 @@ class MessageReceiverAsync(receiver.MessageReceiver):
      from the service that the message was successfully sent. If set to 'Settled',
      the client will not wait for confirmation and assume success.
     :type send_settle_mode: ~uamqp.constants.SenderSettleMode
-    :param desired_capabilities: The extension capabilities desired from the peer endpoint.
-     To create an desired_capabilities object, please do as follows:
+    :param desired_capabilities: The extension capabilities desired from the peer endpoint to be sent in the link ATTACH frame.
+     To create a desired_capabilities object, please do as follows:
         - 1. Create an array of desired capability symbols: `capabilities_symbol_array = [types.AMQPSymbol(string)]`
         - 2. Transform the array to AMQPValue object: `utils.data_factory(types.AMQPArray(capabilities_symbol_array))`
     :type desired_capabilities: ~uamqp.c_uamqp.AMQPValue

--- a/uamqp/client.py
+++ b/uamqp/client.py
@@ -126,6 +126,7 @@ class AMQPClient(object):
         self._properties = kwargs.pop('properties', None)
         self._remote_idle_timeout_empty_frame_send_ratio = kwargs.pop(
             'remote_idle_timeout_empty_frame_send_ratio', None)
+        self._connection_desired_capabilities = kwargs.pop("connection_desired_capabilities", None)
 
         # Session settings
         self._outgoing_window = kwargs.pop('outgoing_window', None) or constants.MAX_FRAME_SIZE_BYTES
@@ -255,7 +256,9 @@ class AMQPClient(object):
                 remote_idle_timeout_empty_frame_send_ratio=self._remote_idle_timeout_empty_frame_send_ratio,
                 error_policy=self._error_policy,
                 debug=self._debug_trace,
-                encoding=self._encoding)
+                encoding=self._encoding,
+                desired_capabilities=self._connection_desired_capabilities
+                )
             self._build_session()
             if self._keep_alive_interval:
                 self._keep_alive_thread = threading.Thread(target=self._keep_alive)

--- a/uamqp/client.py
+++ b/uamqp/client.py
@@ -54,6 +54,16 @@ class AMQPClient(object):
     :type idle_timeout: int
     :param properties: Connection properties.
     :type properties: dict
+    :param desired_capabilities: The extension capabilities desired from the peer endpoint to be sent in the link ATTACH frame.
+     To create an desired_capabilities object, please do as follows:
+        - 1. Create an array of desired capability symbols: `capabilities_symbol_array = [types.AMQPSymbol(string)]`
+        - 2. Transform the array to AMQPValue object: `utils.data_factory(types.AMQPArray(capabilities_symbol_array))`
+    :type desired_capabilities: ~uamqp.c_uamqp.AMQPValue
+    :param connection_desired_capabilities: The extension capabilities desired from the peer endpoint to be sent in the connection OPEN frame.
+     To create a desired_capabilities object, please do as follows:
+        - 1. Create an array of desired capability symbols: `capabilities_symbol_array = [types.AMQPSymbol(string)]`
+        - 2. Transform the array to AMQPValue object: `utils.data_factory(types.AMQPArray(capabilities_symbol_array))`
+    :type connection_desired_capabilities: ~uamqp.c_uamqp.AMQPValue
     :param remote_idle_timeout_empty_frame_send_ratio: Ratio of empty frames to
      idle time for Connections with no activity. Value must be between
      0.0 and 1.0 inclusive. Default is 0.5.
@@ -826,11 +836,6 @@ class ReceiveClient(AMQPClient):
      will assume successful receipt of the message and clear it from the queue. The
      default is `PeekLock`.
     :type receive_settle_mode: ~uamqp.constants.ReceiverSettleMode
-    :param desired_capabilities: The extension capabilities desired from the peer endpoint.
-     To create an desired_capabilities object, please do as follows:
-        - 1. Create an array of desired capability symbols: `capabilities_symbol_array = [types.AMQPSymbol(string)]`
-        - 2. Transform the array to AMQPValue object: `utils.data_factory(types.AMQPArray(capabilities_symbol_array))`
-    :type desired_capabilities: ~uamqp.c_uamqp.AMQPValue
     :param max_message_size: The maximum allowed message size negotiated for the Link.
     :type max_message_size: int
     :param link_properties: Metadata to be sent in the Link ATTACH frame.

--- a/uamqp/client.py
+++ b/uamqp/client.py
@@ -54,12 +54,14 @@ class AMQPClient(object):
     :type idle_timeout: int
     :param properties: Connection properties.
     :type properties: dict
-    :param desired_capabilities: The extension capabilities desired from the peer endpoint to be sent in the link ATTACH frame.
+    :param desired_capabilities: The extension capabilities desired from the peer
+     endpoint to be sent in the link ATTACH frame.
      To create an desired_capabilities object, please do as follows:
         - 1. Create an array of desired capability symbols: `capabilities_symbol_array = [types.AMQPSymbol(string)]`
         - 2. Transform the array to AMQPValue object: `utils.data_factory(types.AMQPArray(capabilities_symbol_array))`
     :type desired_capabilities: ~uamqp.c_uamqp.AMQPValue
-    :param connection_desired_capabilities: The extension capabilities desired from the peer endpoint to be sent in the connection OPEN frame.
+    :param connection_desired_capabilities: The extension capabilities desired from the peer
+     endpoint to be sent in the connection OPEN frame.
      To create a desired_capabilities object, please do as follows:
         - 1. Create an array of desired capability symbols: `capabilities_symbol_array = [types.AMQPSymbol(string)]`
         - 2. Transform the array to AMQPValue object: `utils.data_factory(types.AMQPArray(capabilities_symbol_array))`

--- a/uamqp/connection.py
+++ b/uamqp/connection.py
@@ -48,7 +48,8 @@ class Connection(object):
     :type idle_timeout: int
     :param properties: Connection properties.
     :type properties: dict
-    :param desired_capabilities: The extension capabilities desired from the peer endpoint to be sent in the connection OPEN frame.
+    :param desired_capabilities: The extension capabilities desired from the peer
+     endpoint to be sent in the connection OPEN frame.
      To create a desired_capabilities object, please do as follows:
         - 1. Create an array of desired capability symbols: `capabilities_symbol_array = [types.AMQPSymbol(string)]`
         - 2. Transform the array to AMQPValue object: `utils.data_factory(types.AMQPArray(capabilities_symbol_array))`

--- a/uamqp/connection.py
+++ b/uamqp/connection.py
@@ -48,6 +48,11 @@ class Connection(object):
     :type idle_timeout: int
     :param properties: Connection properties.
     :type properties: dict
+    :param desired_capabilities: The extension capabilities desired from the peer endpoint to be sent in the connection OPEN frame.
+     To create a desired_capabilities object, please do as follows:
+        - 1. Create an array of desired capability symbols: `capabilities_symbol_array = [types.AMQPSymbol(string)]`
+        - 2. Transform the array to AMQPValue object: `utils.data_factory(types.AMQPArray(capabilities_symbol_array))`
+    :type desired_capabilities: ~uamqp.c_uamqp.AMQPValue
     :param remote_idle_timeout_empty_frame_send_ratio: Ratio of empty frames to
      idle time for Connections with no activity. Value must be between
      0.0 and 1.0 inclusive. Default is 0.5.
@@ -66,11 +71,11 @@ class Connection(object):
                  channel_max=None,
                  idle_timeout=None,
                  properties=None,
+                 desired_capabilities=None,
                  remote_idle_timeout_empty_frame_send_ratio=None,
                  error_policy=None,
                  debug=False,
-                 encoding='UTF-8',
-                 desired_capabilities=None):
+                 encoding='UTF-8'):
         uamqp._Platform.initialize()  # pylint: disable=protected-access
         self.container_id = container_id if container_id else str(uuid.uuid4())
         if isinstance(self.container_id, six.text_type):

--- a/uamqp/connection.py
+++ b/uamqp/connection.py
@@ -69,7 +69,8 @@ class Connection(object):
                  remote_idle_timeout_empty_frame_send_ratio=None,
                  error_policy=None,
                  debug=False,
-                 encoding='UTF-8'):
+                 encoding='UTF-8',
+                 desired_capabilities=None):
         uamqp._Platform.initialize()  # pylint: disable=protected-access
         self.container_id = container_id if container_id else str(uuid.uuid4())
         if isinstance(self.container_id, six.text_type):
@@ -102,6 +103,8 @@ class Connection(object):
             self.properties = properties
         if remote_idle_timeout_empty_frame_send_ratio:
             self._conn.remote_idle_timeout_empty_frame_send_ratio = remote_idle_timeout_empty_frame_send_ratio
+        if desired_capabilities:
+            self.desired_capabilities = desired_capabilities
 
     def __enter__(self):
         """Open the Connection in a context manager."""
@@ -309,6 +312,17 @@ class Connection(object):
         if not isinstance(value, dict):
             raise TypeError("Connection properties must be a dictionary.")
         self._conn.properties = utils.data_factory(value, encoding=self._encoding)
+
+    @property
+    def desired_capabilities(self):
+        return self._conn.desired_capabilities
+
+    @desired_capabilities.setter
+    def desired_capabilities(self, value):
+        if not isinstance(value, uamqp.c_uamqp.AMQPValue):
+            raise TypeError("Connection desired capabilities must be type of uamqp.c_uamqp.AMQPValue.\
+                Please use uamqp.utils.data_factory method to encode desired capabilities first")
+        self._conn.desired_capabilities = value
 
     @property
     def remote_max_frame_size(self):

--- a/uamqp/receiver.py
+++ b/uamqp/receiver.py
@@ -52,7 +52,8 @@ class MessageReceiver(object):
      from the service that the message was successfully sent. If set to 'Settled',
      the client will not wait for confirmation and assume success.
     :type send_settle_mode: ~uamqp.constants.SenderSettleMode
-    :param desired_capabilities: The extension capabilities desired from the peer endpoint to be sent in the link ATTACH frame.
+    :param desired_capabilities: The extension capabilities desired from the peer 
+     endpoint to be sent in the link ATTACH frame.
      To create a desired_capabilities object, please do as follows:
         - 1. Create an array of desired capability symbols: `capabilities_symbol_array = [types.AMQPSymbol(string)]`
         - 2. Transform the array to AMQPValue object: `utils.data_factory(types.AMQPArray(capabilities_symbol_array))`

--- a/uamqp/receiver.py
+++ b/uamqp/receiver.py
@@ -52,8 +52,8 @@ class MessageReceiver(object):
      from the service that the message was successfully sent. If set to 'Settled',
      the client will not wait for confirmation and assume success.
     :type send_settle_mode: ~uamqp.constants.SenderSettleMode
-    :param desired_capabilities: The extension capabilities desired from the peer endpoint.
-     To create an desired_capabilities object, please do as follows:
+    :param desired_capabilities: The extension capabilities desired from the peer endpoint to be sent in the link ATTACH frame.
+     To create a desired_capabilities object, please do as follows:
         - 1. Create an array of desired capability symbols: `capabilities_symbol_array = [types.AMQPSymbol(string)]`
         - 2. Transform the array to AMQPValue object: `utils.data_factory(types.AMQPArray(capabilities_symbol_array))`
     :type desired_capabilities: ~uamqp.c_uamqp.AMQPValue

--- a/uamqp/receiver.py
+++ b/uamqp/receiver.py
@@ -52,7 +52,7 @@ class MessageReceiver(object):
      from the service that the message was successfully sent. If set to 'Settled',
      the client will not wait for confirmation and assume success.
     :type send_settle_mode: ~uamqp.constants.SenderSettleMode
-    :param desired_capabilities: The extension capabilities desired from the peer 
+    :param desired_capabilities: The extension capabilities desired from the peer
      endpoint to be sent in the link ATTACH frame.
      To create a desired_capabilities object, please do as follows:
         - 1. Create an array of desired capability symbols: `capabilities_symbol_array = [types.AMQPSymbol(string)]`


### PR DESCRIPTION
The desired capabilities of a connection is described in the amqp protocol, the information is put into the `OPEN` frame.

However, it's not able to verify this feature -- currently the iothub redirect takes place even `amqp:link:redirect` is not put into the desired-capabilities. But the service side requires this as in the future they would check the information.


for more context:
redirect could happen on link or connection level
could be related to EH redirect support