### PR TITLE
Deprecate i386 builds for macOS

### DIFF
--- a/.azure-pipelines/client.openssl.yml
+++ b/.azure-pipelines/client.openssl.yml
@@ -8,7 +8,7 @@ jobs:
   - job: 'OpenSSL'
 
     pool:
-      vmImage: 'macOS-10.14'
+      vmImage: 'macOS-10.15'
 
     strategy:
       matrix:

--- a/.azure-pipelines/client.openssl.yml
+++ b/.azure-pipelines/client.openssl.yml
@@ -21,9 +21,6 @@ jobs:
       - script: sudo xcode-select --switch /Applications/Xcode_11.3.1.app
         displayName: 'Select Xcode 11.3.1'
 
-      - script: sudo installer -pkg /Library/Developer/CommandLineTools/Packages/macOS_SDK_headers_for_macOS_10.15.pkg -target /
-        displayName: 'Install MacOS headers'
-
       - script: source ./build_openssl_osx.sh
         displayName: 'Build OpenSSL'
         env:

--- a/.azure-pipelines/client.openssl.yml
+++ b/.azure-pipelines/client.openssl.yml
@@ -18,10 +18,10 @@ jobs:
           MacOSXDeploymentTarget: '10.9'
 
     steps:
-      - script: sudo xcode-select --switch /Applications/Xcode_9.4.1.app
-        displayName: 'Select Xcode 9.4.1'
+      - script: sudo xcode-select --switch /Applications/Xcode_11.3.1.app
+        displayName: 'Select Xcode 11.3.1'
 
-      - script: sudo installer -pkg /Library/Developer/CommandLineTools/Packages/macOS_SDK_headers_for_macOS_10.14.pkg -target /
+      - script: sudo installer -pkg /Library/Developer/CommandLineTools/Packages/macOS_SDK_headers_for_macOS_10.15.pkg -target /
         displayName: 'Install MacOS headers'
 
       - script: source ./build_openssl_osx.sh

--- a/.azure-pipelines/client.openssl.yml
+++ b/.azure-pipelines/client.openssl.yml
@@ -2,20 +2,14 @@ trigger: none
 pr: none
 
 variables:
-  OpenSSLVersion: '1.0.2t'
+  OpenSSLVersion: '1.0.2u'
+  MacOSXDeploymentTarget: '10.9'
 
 jobs:
   - job: 'OpenSSL'
 
     pool:
       vmImage: 'macOS-10.15'
-
-    strategy:
-      matrix:
-        MacOS 10.6:
-          MacOSXDeploymentTarget: '10.6'
-        MacOS 10.9:
-          MacOSXDeploymentTarget: '10.9'
 
     steps:
       - script: sudo xcode-select --switch /Applications/Xcode_11.3.1.app

--- a/.azure-pipelines/client.test.live.yml
+++ b/.azure-pipelines/client.test.live.yml
@@ -167,9 +167,6 @@ jobs:
       - script: sudo xcode-select --switch /Applications/Xcode_11.3.1.app
         displayName: 'Select Xcode 11.3.1'
 
-      - script: sudo installer -pkg /Library/Developer/CommandLineTools/Packages/macOS_SDK_headers_for_macOS_10.15.pkg -target /
-        displayName: 'Install MacOS headers'
-
       - script: source ./install_python_osx.sh
         displayName: 'Install Official Python'
 

--- a/.azure-pipelines/client.test.live.yml
+++ b/.azure-pipelines/client.test.live.yml
@@ -119,7 +119,7 @@ jobs:
     timeoutInMinutes: 120
 
     pool:
-      vmImage: 'macOS-10.14'
+      vmImage: 'macOS-10.15'
 
     strategy:
       maxParallel: 1

--- a/.azure-pipelines/client.test.live.yml
+++ b/.azure-pipelines/client.test.live.yml
@@ -164,10 +164,10 @@ jobs:
           pipeline: 119 # azure-uamqp-python - openssl
           project: '29ec6040-b234-4e31-b139-33dc4287b756' # public
 
-      - script: sudo xcode-select --switch /Applications/Xcode_9.4.1.app
-        displayName: 'Select Xcode 9.4.1'
+      - script: sudo xcode-select --switch /Applications/Xcode_11.3.1.app
+        displayName: 'Select Xcode 11.3.1'
 
-      - script: sudo installer -pkg /Library/Developer/CommandLineTools/Packages/macOS_SDK_headers_for_macOS_10.14.pkg -target /
+      - script: sudo installer -pkg /Library/Developer/CommandLineTools/Packages/macOS_SDK_headers_for_macOS_10.15.pkg -target /
         displayName: 'Install MacOS headers'
 
       - script: source ./install_python_osx.sh

--- a/.azure-pipelines/client.test.live.yml
+++ b/.azure-pipelines/client.test.live.yml
@@ -125,33 +125,29 @@ jobs:
       maxParallel: 1
       matrix:
         Python 2.7:
-          MacOSXDeploymentTarget: '10.6'
           PythonBin: 'python2'
           PythonVersion: '$(PythonVersion27)'
         Python 3.5:
-          MacOSXDeploymentTarget: '10.6'
           PythonBin: 'python3'
           PythonVersion: '$(PythonVersion35)'
         Python 3.6:
-          MacOSXDeploymentTarget: '10.6'
           PythonBin: 'python3'
           PythonVersion: '$(PythonVersion36)'
         Python 3.7:
-          MacOSXDeploymentTarget: '10.6'
           PythonBin: 'python3'
           PythonVersion: '$(PythonVersion37)'
         Python 3.8:
-          MacOSXDeploymentTarget: '10.9'
           PythonBin: 'python3'
           PythonVersion: '$(PythonVersion38)'
 
     variables:
+      MacOSXDeploymentTarget: '10.9'
       OpenSSLDir: $(Agent.BuildDirectory)/openssl-macosx$(MacOSXDeploymentTarget)
       PythonVersion27: '2.7.17'
       PythonVersion35: '3.5.4'
       PythonVersion36: '3.6.8'
-      PythonVersion37: '3.7.5'
-      PythonVersion38: '3.8.0'
+      PythonVersion37: '3.7.6'
+      PythonVersion38: '3.8.2'
 
     steps:
       - task: DownloadPipelineArtifact@1
@@ -188,7 +184,7 @@ jobs:
         displayName: 'Build uAMQP Wheel'
         env:
           CFLAGS: -mmacosx-version-min=$(MacOSXDeploymentTarget) -I$(OpenSSLDir)/include
-          CMAKE_OSX_ARCHITECTURES: 'i386;x86_64'
+          CMAKE_OSX_ARCHITECTURES: 'x86_64'
           CMAKE_OSX_DEPLOYMENT_TARGET: $(MacOSXDeploymentTarget)
           LDFLAGS: -mmacosx-version-min=$(MacOSXDeploymentTarget) -L$(OpenSSLDir)/lib
           MACOSX_DEPLOYMENT_TARGET: $(MacOSXDeploymentTarget)

--- a/.azure-pipelines/client.yml
+++ b/.azure-pipelines/client.yml
@@ -46,7 +46,7 @@ jobs:
   - job: 'MacOS'
 
     pool:
-      vmImage: 'macOS-10.14'
+      vmImage: 'macOS-10.15'
 
     strategy:
       matrix:

--- a/.azure-pipelines/client.yml
+++ b/.azure-pipelines/client.yml
@@ -93,9 +93,6 @@ jobs:
       - script: sudo xcode-select --switch /Applications/Xcode_11.3.1.app
         displayName: 'Select Xcode 11.3.1'
 
-      - script: sudo installer -pkg /Library/Developer/CommandLineTools/Packages/macOS_SDK_headers_for_macOS_10.15.pkg -target /
-        displayName: 'Install MacOS headers'
-
       - script: source ./install_python_osx.sh
         displayName: 'Install Official Python'
 

--- a/.azure-pipelines/client.yml
+++ b/.azure-pipelines/client.yml
@@ -90,10 +90,10 @@ jobs:
           pipeline: 119 # azure-uamqp-python - openssl
           project: '29ec6040-b234-4e31-b139-33dc4287b756' # public
 
-      - script: sudo xcode-select --switch /Applications/Xcode_9.4.1.app
-        displayName: 'Select Xcode 9.4.1'
+      - script: sudo xcode-select --switch /Applications/Xcode_11.3.1.app
+        displayName: 'Select Xcode 11.3.1'
 
-      - script: sudo installer -pkg /Library/Developer/CommandLineTools/Packages/macOS_SDK_headers_for_macOS_10.14.pkg -target /
+      - script: sudo installer -pkg /Library/Developer/CommandLineTools/Packages/macOS_SDK_headers_for_macOS_10.15.pkg -target /
         displayName: 'Install MacOS headers'
 
       - script: source ./install_python_osx.sh

--- a/.azure-pipelines/client.yml
+++ b/.azure-pipelines/client.yml
@@ -51,33 +51,29 @@ jobs:
     strategy:
       matrix:
         Python 2.7:
-          MacOSXDeploymentTarget: '10.6'
           PythonBin: 'python2'
           PythonVersion: '$(PythonVersion27)'
         Python 3.5:
-          MacOSXDeploymentTarget: '10.6'
           PythonBin: 'python3'
           PythonVersion: '$(PythonVersion35)'
         Python 3.6:
-          MacOSXDeploymentTarget: '10.6'
           PythonBin: 'python3'
           PythonVersion: '$(PythonVersion36)'
         Python 3.7:
-          MacOSXDeploymentTarget: '10.6'
           PythonBin: 'python3'
           PythonVersion: '$(PythonVersion37)'
         Python 3.8:
-          MacOSXDeploymentTarget: '10.9'
           PythonBin: 'python3'
           PythonVersion: '$(PythonVersion38)'
 
     variables:
+      MacOSXDeploymentTarget: '10.9'
       OpenSSLDir: $(Agent.BuildDirectory)/openssl-macosx$(MacOSXDeploymentTarget)
       PythonVersion27: '2.7.17'
       PythonVersion35: '3.5.4'
       PythonVersion36: '3.6.8'
-      PythonVersion37: '3.7.5'
-      PythonVersion38: '3.8.0'
+      PythonVersion37: '3.7.6'
+      PythonVersion38: '3.8.2'
 
     steps:
       - task: DownloadPipelineArtifact@1
@@ -114,7 +110,7 @@ jobs:
         displayName: 'Build uAMQP Wheel'
         env:
           CFLAGS: -mmacosx-version-min=$(MacOSXDeploymentTarget) -I$(OpenSSLDir)/include
-          CMAKE_OSX_ARCHITECTURES: 'i386;x86_64'
+          CMAKE_OSX_ARCHITECTURES: 'x86_64'
           CMAKE_OSX_DEPLOYMENT_TARGET: $(MacOSXDeploymentTarget)
           LDFLAGS: -mmacosx-version-min=$(MacOSXDeploymentTarget) -L$(OpenSSLDir)/lib
           MACOSX_DEPLOYMENT_TARGET: $(MacOSXDeploymentTarget)

--- a/build_openssl_osx.sh
+++ b/build_openssl_osx.sh
@@ -1,34 +1,19 @@
 #!/bin/bash
 
-# Modified from https://gist.github.com/tmiz/1441111
-
 # Acquire sources
 curl -sSO https://www.openssl.org/source/openssl-$OPENSSL_VERSION.tar.gz
 tar -xzf openssl-$OPENSSL_VERSION.tar.gz
 rm -f openssl-$OPENSSL_VERSION.tar.gz
-
-# Set up two build environments
-cp -R openssl-$OPENSSL_VERSION openssl_i386_src
-mv openssl-$OPENSSL_VERSION openssl_x86_64_src
-
-# Compile i386
-cd openssl_i386_src
-./Configure darwin-i386-cc no-ssl2 no-ssl3 no-zlib no-shared no-comp --prefix=$DEST/openssl --openssldir=$DEST/openssl
-make depend
-make
-make install_sw
-mv $DEST/openssl $DEST/openssl_i386
+mv openssl-$OPENSSL_VERSION openssl_src
 
 # Compile x86_64
-cd ../openssl_x86_64_src
+cd ../openssl_src
 ./Configure darwin64-x86_64-cc enable-ec_nistp_64_gcc_128 no-ssl2 no-ssl3 no-zlib no-shared no-comp --prefix=$DEST/openssl --openssldir=$DEST/openssl
 make depend
 make
 make install_sw
-mv $DEST/openssl $DEST/openssl_x86_64
 
-# Move files into place and generate universal binaries
+# Move files into place
 cd $DEST
-cp -a ./openssl_x86_64/. ./openssl/
-lipo -create openssl_i386/lib/libcrypto.a openssl_x86_64/lib/libcrypto.a -output openssl/lib/libazcrypto.a
-lipo -create openssl_i386/lib/libssl.a openssl_x86_64/lib/libssl.a -output openssl/lib/libazssl.a
+mv openssl/lib/libcrypto.a openssl/lib/libazcrypto.a
+mv openssl/lib/libssl.a openssl/lib/libazssl.a

--- a/build_osx.sh
+++ b/build_osx.sh
@@ -1,15 +1,15 @@
 #!/bin/bash
 set -e
-export MACOSX_DEPLOYMENT_TARGET=10.6
-export CMAKE_OSX_DEPLOYMENT_TARGET=10.6
-export CMAKE_OSX_ARCHITECTURES="i386;x86_64"
+export MACOSX_DEPLOYMENT_TARGET=10.9
+export CMAKE_OSX_DEPLOYMENT_TARGET=10.9
+export CMAKE_OSX_ARCHITECTURES="x86_64"
 export UAMQP_USE_OPENSSL=True
 export UAMQP_REBUILD_PYX=True
 export UAMQP_SUPPRESS_LINK_FLAGS=True
 export OPENSSL_ROOT_DIR="/tmp/openssl"
 export OPENSSL_INCLUDE_DIR="/tmp/openssl/include"
-export LDFLAGS="-mmacosx-version-min=10.6 -L/tmp/openssl/lib"
-export CFLAGS="-mmacosx-version-min=10.6 -I/tmp/openssl/include"
+export LDFLAGS="-mmacosx-version-min=10.9 -L/tmp/openssl/lib"
+export CFLAGS="-mmacosx-version-min=10.9 -I/tmp/openssl/include"
 
 python2.7 setup.py bdist_wheel
 python3.4 setup.py bdist_wheel

--- a/install_python_osx.sh
+++ b/install_python_osx.sh
@@ -1,9 +1,9 @@
 #!/bin/bash
 
-# Python 3.8+ are only build for OSX 10.9+
-PACKAGE_TYPE="macosx10.6"
-if [[ "$PYTHONVERSION" =~ ^3.8 ]]; then
-  PACKAGE_TYPE="macosx10.9"
+# Python 3.5 is only built for OSX 10.6+
+PACKAGE_TYPE="macosx10.9"
+if [[ "$PYTHONVERSION" =~ ^3.5 ]]; then
+  PACKAGE_TYPE="macosx10.6"
 fi
 
 # Handle prerelease versions


### PR DESCRIPTION
As of Xcode 10+, 32-bit support for compiled binaries has been deprecated. We've been maintaining 32-bit wheel builds for Mac by using an old build of Xcode 9, but this is no longer included on the macOS 10.15 VM images. Based on telemetry, we've decide to sunset support for 32-bit wheel builds for Mac, rather than downloading an ancient Xcode during the build step.

- [x] Stop building universal binaries of OpenSSL on Mac (x86_86 only now)
- [x] Set the min deployment target to "10.9" everywhere
- [x] Remove the i386 cmake build target for uamqp-python
- [x] Update to current versions of macOS and Xcode

https://github.com/Azure/azure-sdk/issues/1014