### PR TITLE
Keep receiver alive after timeout and reuse

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -3,10 +3,10 @@
 Release History
 ===============
 
-1.2.10 (Unreleased)
+1.2.10 (2020-08-05)
 +++++++++++++++++++
 
-- Added parameter `shutdown_after_timeout` to `ReceiveClient` and `ReceiveClientAsync` which gives control over the whether to shutdown receiver after timeout.
+- Added parameter `shutdown_after_timeout` to `ReceiveClient` and `ReceiveClientAsync` which gives control over whether to shutdown receiver after timeout.
 
 1.2.9 (2020-07-06)
 ++++++++++++++++++

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -3,6 +3,11 @@
 Release History
 ===============
 
+1.2.10 (Unreleased)
+++++++++++++++++++
+
+- Added parameter `shutdown_after_timeout` to `ReceiveClient` and `ReceiveClientAsync` which gives control over the whether to shutdown receiver after timeout.
+
 1.2.9 (2020-07-06)
 ++++++++++++++++++
 

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -4,7 +4,7 @@ Release History
 ===============
 
 1.2.10 (Unreleased)
-++++++++++++++++++
++++++++++++++++++++
 
 - Added parameter `shutdown_after_timeout` to `ReceiveClient` and `ReceiveClientAsync` which gives control over the whether to shutdown receiver after timeout.
 

--- a/samples/test_azure_event_hubs_receive.py
+++ b/samples/test_azure_event_hubs_receive.py
@@ -265,8 +265,103 @@ def test_event_hubs_iter_receive_sync(live_eventhub_config):
             log.info("Got {} more messages. Shutting down.".format(count))
             message.accept()
             break
-    
+
     receive_client.close()
+
+
+def test_event_hubs_iter_receive_no_shutdown_after_timeout_sync(live_eventhub_config):
+    uri = "sb://{}/{}".format(live_eventhub_config['hostname'], live_eventhub_config['event_hub'])
+    sas_auth = authentication.SASTokenAuth.from_shared_access_key(
+        uri, live_eventhub_config['key_name'], live_eventhub_config['access_key'])
+    source = "amqps://{}/{}/ConsumerGroups/{}/Partitions/{}".format(
+        live_eventhub_config['hostname'],
+        live_eventhub_config['event_hub'],
+        live_eventhub_config['consumer_group'],
+        live_eventhub_config['partition'])
+
+    source = address.Source(source)
+    source.set_filter(b"amqp.annotation.x-opt-offset > '@latest'")
+    receive_client = uamqp.ReceiveClient(source, auth=sas_auth, timeout=2000, debug=False, shutdown_after_timeout=False)
+    count = 0
+
+    receive_client.open()
+    while not receive_client.client_ready():
+        receive_client.do_work()
+
+    gen = receive_client.receive_messages_iter()
+
+    send_single_message(live_eventhub_config, live_eventhub_config['partition'], 'message')
+    for message in gen:
+        log.info(message.annotations.get(b'x-opt-sequence-number'))
+        log.info(str(message))
+        count += 1
+
+    assert count == 1
+    count = 0
+
+    message_handler_before = receive_client.message_handler
+    send_single_message(live_eventhub_config, live_eventhub_config['partition'], 'message')
+    gen = receive_client.receive_messages_iter()
+
+    for message in gen:
+        log.info(message.annotations.get(b'x-opt-sequence-number'))
+        log.info(str(message))
+        count += 1
+
+    assert count == 1
+
+    message_handler_after = receive_client.message_handler
+    assert message_handler_before == message_handler_after
+
+    receive_client.close()
+
+
+def event_hubs_iter_receive_no_shutdown_after_timeout_sync_option2(live_eventhub_config):
+    uri = "sb://{}/{}".format(live_eventhub_config['hostname'], live_eventhub_config['event_hub'])
+
+    sas_auth = authentication.SASTokenAuth.from_shared_access_key(
+        uri, live_eventhub_config['key_name'], live_eventhub_config['access_key'])
+    source = "amqps://{}/{}/ConsumerGroups/{}/Partitions/{}".format(
+        live_eventhub_config['hostname'],
+        live_eventhub_config['event_hub'],
+        live_eventhub_config['consumer_group'],
+        live_eventhub_config['partition'])
+
+    source = address.Source(source)
+    source.set_filter(b"amqp.annotation.x-opt-offset > '@latest'")
+    receive_client = uamqp.ReceiveClient(source, auth=sas_auth, timeout=2000, debug=False, shutdown_after_timeout=False)
+    count = 0
+
+    receive_client.open()
+    while not receive_client.client_ready():
+        receive_client.do_work()
+
+    gen = receive_client._message_reusable_generator()
+
+    send_single_message(live_eventhub_config, live_eventhub_config['partition'], 'message')
+    for message in gen:
+        log.info(message.annotations.get(b'x-opt-sequence-number'))
+        log.info(str(message))
+        count += 1
+
+    assert count == 1
+    count = 0
+
+    message_handler_before = receive_client.message_handler
+    send_single_message(live_eventhub_config, live_eventhub_config['partition'], 'message')
+
+    for message in gen:
+        log.info(message.annotations.get(b'x-opt-sequence-number'))
+        log.info(str(message))
+        count += 1
+
+    assert count == 1
+
+    message_handler_after = receive_client.message_handler
+    assert message_handler_before == message_handler_after
+
+    receive_client.close()
+
 
 
 def test_event_hubs_shared_connection(live_eventhub_config):
@@ -373,4 +468,4 @@ if __name__ == '__main__':
     config['access_key'] = os.environ['EVENT_HUB_SAS_KEY']
     config['consumer_group'] = "$Default"
     config['partition'] = "0"
-    test_event_hubs_client_receive_sync(config)
+    test_event_hubs_iter_receive_no_shutdown_after_timeout_sync(config)

--- a/samples/test_azure_event_hubs_receive.py
+++ b/samples/test_azure_event_hubs_receive.py
@@ -178,6 +178,44 @@ def test_event_hubs_client_receive_sync(live_eventhub_config):
     log.info("Finished receiving")
 
 
+def test_event_hubs_client_receive_no_shutdown_after_timeout_sync(live_eventhub_config):
+    uri = "sb://{}/{}".format(live_eventhub_config['hostname'], live_eventhub_config['event_hub'])
+    sas_auth = authentication.SASTokenAuth.from_shared_access_key(
+        uri, live_eventhub_config['key_name'], live_eventhub_config['access_key'])
+
+    source = "amqps://{}/{}/ConsumerGroups/{}/Partitions/{}".format(
+        live_eventhub_config['hostname'],
+        live_eventhub_config['event_hub'],
+        live_eventhub_config['consumer_group'],
+        live_eventhub_config['partition'])
+
+    source = address.Source(source)
+    source.set_filter(b"amqp.annotation.x-opt-offset > '@latest'")
+    received_cnt = 0
+
+    with uamqp.ReceiveClient(source, auth=sas_auth, timeout=2000, debug=False, shutdown_after_timeout=False) as receive_client:
+        log.info("Created client, receiving...")
+
+        received_cnt += len(receive_client.receive_message_batch(max_batch_size=10))
+        assert received_cnt == 0
+
+        message_handler_before = receive_client.message_handler
+
+        send_single_message(live_eventhub_config, live_eventhub_config['partition'], 'message')
+        received_cnt += len(receive_client.receive_message_batch(max_batch_size=10))
+        assert received_cnt == 1
+
+        received_cnt += len(receive_client.receive_message_batch(max_batch_size=10))
+        assert received_cnt == 1
+
+        send_single_message(live_eventhub_config, live_eventhub_config['partition'], 'message')
+        received_cnt += len(receive_client.receive_message_batch(max_batch_size=10))
+        message_handler_after = receive_client.message_handler
+
+        assert message_handler_before == message_handler_after
+        assert received_cnt == 2
+
+
 def test_event_hubs_client_receive_with_runtime_metric_sync(live_eventhub_config):
     uri = "sb://{}/{}".format(live_eventhub_config['hostname'], live_eventhub_config['event_hub'])
     sas_auth = authentication.SASTokenAuth.from_shared_access_key(
@@ -235,6 +273,52 @@ def test_event_hubs_callback_receive_sync(live_eventhub_config):
     
     receive_client.receive_messages(on_message_received)
     log.info("Finished receiving")
+
+
+def test_event_hubs_callback_receive_no_shutdown_after_timeout_sync(live_eventhub_config):
+    received_cnt = {'cnt': 0}
+
+    def on_message_received(message):
+        annotations = message.annotations
+        log.info("Sequence Number: {}".format(annotations.get(b'x-opt-sequence-number')))
+        log.info(str(message))
+        message.accept()
+        received_cnt['cnt'] += 1
+
+    uri = "sb://{}/{}".format(live_eventhub_config['hostname'], live_eventhub_config['event_hub'])
+    sas_auth = authentication.SASTokenAuth.from_shared_access_key(
+        uri, live_eventhub_config['key_name'], live_eventhub_config['access_key'])
+
+    source = "amqps://{}/{}/ConsumerGroups/{}/Partitions/{}".format(
+        live_eventhub_config['hostname'],
+        live_eventhub_config['event_hub'],
+        live_eventhub_config['consumer_group'],
+        live_eventhub_config['partition'])
+    
+    source = address.Source(source)
+    source.set_filter(b"amqp.annotation.x-opt-offset > '@latest'")
+
+    receive_client = uamqp.ReceiveClient(source, auth=sas_auth, timeout=2000, debug=False, shutdown_after_timeout=False)
+    log.info("Created client, receiving...")
+    
+    receive_client.open()
+    while not receive_client.client_ready():
+        receive_client.do_work()
+
+    send_single_message(live_eventhub_config, live_eventhub_config['partition'], 'message')
+    receive_client.receive_messages(on_message_received)
+    message_handler_before = receive_client.message_handler
+    assert received_cnt['cnt'] == 1
+
+    send_single_message(live_eventhub_config, live_eventhub_config['partition'], 'message')
+    receive_client.receive_messages(on_message_received)
+    message_handler_after = receive_client.message_handler
+    assert message_handler_before == message_handler_after
+
+    assert received_cnt['cnt'] == 2
+
+    log.info("Finished receiving")
+    receive_client.close()
 
 
 def test_event_hubs_iter_receive_sync(live_eventhub_config):
@@ -420,4 +504,4 @@ if __name__ == '__main__':
     config['access_key'] = os.environ['EVENT_HUB_SAS_KEY']
     config['consumer_group'] = "$Default"
     config['partition'] = "0"
-    test_event_hubs_iter_receive_no_shutdown_after_timeout_sync(config)
+    test_event_hubs_client_receive_no_shutdown_after_timeout_sync(config)

--- a/samples/test_azure_event_hubs_receive.py
+++ b/samples/test_azure_event_hubs_receive.py
@@ -316,54 +316,6 @@ def test_event_hubs_iter_receive_no_shutdown_after_timeout_sync(live_eventhub_co
     receive_client.close()
 
 
-def event_hubs_iter_receive_no_shutdown_after_timeout_sync_option2(live_eventhub_config):
-    uri = "sb://{}/{}".format(live_eventhub_config['hostname'], live_eventhub_config['event_hub'])
-
-    sas_auth = authentication.SASTokenAuth.from_shared_access_key(
-        uri, live_eventhub_config['key_name'], live_eventhub_config['access_key'])
-    source = "amqps://{}/{}/ConsumerGroups/{}/Partitions/{}".format(
-        live_eventhub_config['hostname'],
-        live_eventhub_config['event_hub'],
-        live_eventhub_config['consumer_group'],
-        live_eventhub_config['partition'])
-
-    source = address.Source(source)
-    source.set_filter(b"amqp.annotation.x-opt-offset > '@latest'")
-    receive_client = uamqp.ReceiveClient(source, auth=sas_auth, timeout=2000, debug=False, shutdown_after_timeout=False)
-    count = 0
-
-    receive_client.open()
-    while not receive_client.client_ready():
-        receive_client.do_work()
-
-    gen = receive_client._message_reusable_generator()
-
-    send_single_message(live_eventhub_config, live_eventhub_config['partition'], 'message')
-    for message in gen:
-        log.info(message.annotations.get(b'x-opt-sequence-number'))
-        log.info(str(message))
-        count += 1
-
-    assert count == 1
-    count = 0
-
-    message_handler_before = receive_client.message_handler
-    send_single_message(live_eventhub_config, live_eventhub_config['partition'], 'message')
-
-    for message in gen:
-        log.info(message.annotations.get(b'x-opt-sequence-number'))
-        log.info(str(message))
-        count += 1
-
-    assert count == 1
-
-    message_handler_after = receive_client.message_handler
-    assert message_handler_before == message_handler_after
-
-    receive_client.close()
-
-
-
 def test_event_hubs_shared_connection(live_eventhub_config):
     uri = "sb://{}/{}".format(live_eventhub_config['hostname'], live_eventhub_config['event_hub'])
     sas_auth = authentication.SASTokenAuth.from_shared_access_key(

--- a/uamqp/__init__.py
+++ b/uamqp/__init__.py
@@ -35,7 +35,7 @@ except (SyntaxError, ImportError):
     pass  # Async not supported.
 
 
-__version__ = "1.2.9"
+__version__ = "1.2.10"
 
 
 _logger = logging.getLogger(__name__)

--- a/uamqp/async_ops/client_async.py
+++ b/uamqp/async_ops/client_async.py
@@ -997,7 +997,7 @@ class AsyncMessageIter(collections.abc.AsyncIterator):  # pylint: disable=no-mem
     def __init__(self, rcv_client, auto_complete=True):
         self._client = rcv_client
         self._client.auto_complete = False
-        self._client._timeout_reached = False
+        self._client._timeout_reached = False  # pylint: disable=protected-access
         self.receiving = True
         self.auto_complete = auto_complete
         self.current_message = None

--- a/uamqp/async_ops/client_async.py
+++ b/uamqp/async_ops/client_async.py
@@ -692,7 +692,11 @@ class ReceiveClientAsync(client.ReceiveClient, AMQPClientAsync):
     :param timeout: A timeout in milliseconds. The receiver will shut down if no
      new messages are received after the specified timeout. If set to 0, the receiver
      will never timeout and will continue to listen. The default is 0.
+     Set `shutdown_after_timeout` to `False` if keeping the receiver open after timeout is needed.
     :type timeout: float
+    :param shutdown_after_timeout: Whether to automatically shutdown the receiver
+     if no new messages are received after the specified timeout. Default is `True`.
+    :type shutdown_after_timeout: bool
     :param auto_complete: Whether to automatically settle message received via callback
      or via iterator. If the message has not been explicitly settled after processing
      the message will be accepted. Alternatively, when used with batch receive, this setting
@@ -845,7 +849,7 @@ class ReceiveClientAsync(client.ReceiveClient, AMQPClientAsync):
                         _logger.info("Timeout reached, closing receiver.")
                         self._shutdown = True
                     else:
-                        self._last_activity_timestamp = None # To reuse the receiver, reset the timestamp
+                        self._last_activity_timestamp = None  # To reuse the receiver, reset the timestamp
                         _logger.info("Timeout reached, keeping receiver open.")
         else:
             self._last_activity_timestamp = now
@@ -870,16 +874,18 @@ class ReceiveClientAsync(client.ReceiveClient, AMQPClientAsync):
         self._streaming_receive = True
         await self.open_async()
         self._message_received_callback = on_message_received
+        self._timeout_reached = False
         receiving = True
         try:
-            while receiving:
+            while receiving and not self._timeout_reached:
                 receiving = await self.do_work_async()
         except:
             receiving = False
             raise
         finally:
             self._streaming_receive = False
-            if not receiving:
+            self._timeout_reached = False
+            if not receiving and self._shutdown_after_timeout:
                 await self.close_async()
 
     async def receive_message_batch_async(self, max_batch_size=None, on_message_received=None, timeout=0):
@@ -922,23 +928,27 @@ class ReceiveClientAsync(client.ReceiveClient, AMQPClientAsync):
         if len(batch) >= max_batch_size:
             return batch
 
-        while receiving and not expired and len(batch) < max_batch_size:
-            while receiving and self._received_messages.qsize() < max_batch_size:
-                if timeout and self._counter.get_current_ms() > timeout:
-                    expired = True
-                    break
-                before = self._received_messages.qsize()
-                receiving = await self.do_work_async()
-                received = self._received_messages.qsize() - before
-                if self._received_messages.qsize() > 0 and received == 0:
-                    # No new messages arrived, but we have some - so return what we have.
-                    expired = True
-                    break
+        self._timeout_reached = False
+        try:
+            while receiving and not expired and len(batch) < max_batch_size and not self._timeout_reached:
+                while receiving and self._received_messages.qsize() < max_batch_size and not self._timeout_reached:
+                    if timeout and self._counter.get_current_ms() > timeout:
+                        expired = True
+                        break
+                    before = self._received_messages.qsize()
+                    receiving = await self.do_work_async()
+                    received = self._received_messages.qsize() - before
+                    if self._received_messages.qsize() > 0 and received == 0:
+                        # No new messages arrived, but we have some - so return what we have.
+                        expired = True
+                        break
 
-            while not self._received_messages.empty() and len(batch) < max_batch_size:
-                batch.append(self._received_messages.get())
-                self._received_messages.task_done()
-        return batch
+                while not self._received_messages.empty() and len(batch) < max_batch_size:
+                    batch.append(self._received_messages.get())
+                    self._received_messages.task_done()
+            return batch
+        finally:
+            self._timeout_reached = False
 
     def receive_messages_iter_async(self, on_message_received=None):
         """Receive messages by asynchronous generator. Messages returned in the
@@ -1020,5 +1030,6 @@ class AsyncMessageIter(collections.abc.AsyncIterator):  # pylint: disable=no-mem
             self.receiving = False
             raise
         finally:
+            self._client._timeout_reached = False  # pylint: disable=protected-access
             if not self.receiving and self._client._shutdown_after_timeout:
                 await self._client.close_async()

--- a/uamqp/async_ops/client_async.py
+++ b/uamqp/async_ops/client_async.py
@@ -880,6 +880,7 @@ class ReceiveClientAsync(client.ReceiveClient, AMQPClientAsync):
         try:
             while receiving and not self._timeout_reached:
                 receiving = await self.do_work_async()
+            receiving = False
         except:
             receiving = False
             raise

--- a/uamqp/client.py
+++ b/uamqp/client.py
@@ -1101,6 +1101,7 @@ class ReceiveClient(AMQPClient):
         try:
             while receiving and not self._timeout_reached:
                 receiving = self.do_work()
+            receiving = False
         except:
             receiving = False
             raise


### PR DESCRIPTION
In current world after timeout, the receiver would be shutdown, everything needs to be re-established.

- receiver life cycle control on timeout: added a new kwarg "_shutdown_after_timeout" into ReceiveClient Constructor to allow the upper layer control the life cycle
- after one generator ends, new one can simply be created to continue utilizing the receiver.

To reuse the receiver in the service bus, the code could be:
```python


class ServiceBusReceiver:
    def _create_handler(self, auth):
        self._handler = ReceiveClient(..., shutdown_after_timeout=False)

    def __next__(self):
        self._check_live()
        while True:
            try:
                return self._do_retryable_operation(self._iter_next)
            except StopIteration:
                self._message_iter = None 

    def _iter_next(self):
        self._open()
        if not self._message_iter:
            self._message_iter = self._message_iter = self._handler.receive_messages_iter()  # get a new generator if last one ends
        uamqp_message = next(self._message_iter)
        message = self._build_message(uamqp_message)
        return message

```

