### PR TITLE
message footer and annotation_delivery encoding fix

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -6,8 +6,7 @@ Release History
 1.2.11 (Unreleased)
 +++++++++++++++++++
 
-- Fixed bug where `Message.footer` and `Message.delivery_annotation` not being encoded into the outgoing payload.
-
+- Fixed bug where `Message.footer` and `Message.delivery_annotation` were not encoded into the outgoing payload.
 
 1.2.10 (2020-08-05)
 +++++++++++++++++++

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -3,6 +3,12 @@
 Release History
 ===============
 
+1.2.11 (Unreleased)
++++++++++++++++++++
+
+- Fixed bug where `Message.footer` and `Message.delivery_annotation` not being encoded into the outgoing payload.
+
+
 1.2.10 (2020-08-05)
 +++++++++++++++++++
 

--- a/samples/test_azure_event_hubs_receive.py
+++ b/samples/test_azure_event_hubs_receive.py
@@ -496,6 +496,76 @@ def test_event_hubs_dynamic_issue_link_credit(live_eventhub_config):
     log.info("Finished receiving")
 
 
+def test_event_hubs_send_event_with_amqp_attributes_sync(live_eventhub_config):
+    def data_generator():
+        for i in range(2):
+            msg = uamqp.message.Message(body='Data')
+            # header is only used on received msg, not set on messages being sent
+            msg.application_properties = {'msg_type': 'rich_batch'}
+            msg.properties = uamqp.message.MessageProperties(message_id='richid')
+            msg.footer = {'footerkey':'footervalue'}
+            msg.delivery_annotations = {'deliveryannkey':'deliveryannvalue'}
+            msg.annotations = {'annkey':'annvalue'}
+            yield msg
+
+    uri = "sb://{}/{}".format(live_eventhub_config['hostname'], live_eventhub_config['event_hub'])
+    sas_auth = authentication.SASTokenAuth.from_shared_access_key(
+        uri, live_eventhub_config['key_name'], live_eventhub_config['access_key'])
+
+    target = "amqps://{}/{}/Partitions/0".format(live_eventhub_config['hostname'], live_eventhub_config['event_hub'])
+    send_client = uamqp.SendClient(target, auth=sas_auth, debug=False)
+
+    message = uamqp.message.Message(body='Data')
+    # header is only used on received msg, not set on messages being sent
+    message.application_properties = {'msg_type': 'rich_single'}
+    message.properties = uamqp.message.MessageProperties(message_id='richid')
+    message.footer = {'footerkey':'footervalue'}
+    message.delivery_annotations = {'deliveryannkey':'deliveryannvalue'}
+    message.annotations = {'annkey':'annvalue'}
+    send_client.queue_message(message)
+
+    message_batch = uamqp.message.BatchMessage(data_generator())
+    send_client.queue_message(message_batch)
+    results = send_client.send_all_messages(close_on_done=False)
+    assert not [m for m in results if m == uamqp.constants.MessageState.SendFailed]
+
+    rich_single_received = rich_batch_received = False
+
+    uri = "sb://{}/{}".format(live_eventhub_config['hostname'], live_eventhub_config['event_hub'])
+    sas_auth = authentication.SASTokenAuth.from_shared_access_key(
+        uri, live_eventhub_config['key_name'], live_eventhub_config['access_key'])
+
+    source = "amqps://{}/{}/ConsumerGroups/{}/Partitions/{}".format(
+        live_eventhub_config['hostname'],
+        live_eventhub_config['event_hub'],
+        live_eventhub_config['consumer_group'],
+        0)
+
+    receive_client = uamqp.ReceiveClient(source, auth=sas_auth, timeout=5000, debug=False, prefetch=10)
+    gen = receive_client.receive_messages_iter()
+    for message in gen:
+        if message.application_properties and message.application_properties.get(b'msg_type'):
+            if not rich_single_received:
+                rich_single_received = message.application_properties.get(b'msg_type') == b'rich_single'
+            if not rich_batch_received:
+                rich_batch_received = message.application_properties.get(b'msg_type') == b'rich_batch'
+            assert message.properties.message_id == b'richid'
+            assert message.delivery_annotations
+            assert message.delivery_annotations.get(b'deliveryannkey') == b'deliveryannvalue'
+            assert message.footer
+            assert message.footer.get(b'footerkey') == b'footervalue'
+            assert message.annotations
+            assert message.annotations.get(b'annkey') == b'annvalue'
+
+        log.info(message.annotations.get(b'x-opt-sequence-number'))
+        log.info(str(message))
+
+    send_client.close()
+    receive_client.close()
+
+    assert rich_single_received
+    assert rich_batch_received
+
 if __name__ == '__main__':
     config = {}
     config['hostname'] = os.environ['EVENT_HUB_HOSTNAME']
@@ -504,4 +574,4 @@ if __name__ == '__main__':
     config['access_key'] = os.environ['EVENT_HUB_SAS_KEY']
     config['consumer_group'] = "$Default"
     config['partition'] = "0"
-    test_event_hubs_client_receive_no_shutdown_after_timeout_sync(config)
+    test_event_hubs_send_event_with_amqp_attributes_sync(config)

--- a/samples/test_azure_event_hubs_receive.py
+++ b/samples/test_azure_event_hubs_receive.py
@@ -566,6 +566,7 @@ def test_event_hubs_send_event_with_amqp_attributes_sync(live_eventhub_config):
     assert rich_single_received
     assert rich_batch_received
 
+
 if __name__ == '__main__':
     config = {}
     config['hostname'] = os.environ['EVENT_HUB_HOSTNAME']

--- a/src/message.pyx
+++ b/src/message.pyx
@@ -367,6 +367,7 @@ cdef class Messaging(object):
 
 cdef void destroy_amqp_objects_in_get_encoded_message_size(c_amqp_definitions.HEADER_HANDLE header,
     c_amqpvalue.AMQP_VALUE header_amqp_value, c_amqpvalue.AMQP_VALUE msg_annotations,
+    c_amqpvalue.AMQP_VALUE footer, c_amqpvalue.AMQP_VALUE delivery_annotations,
     c_amqp_definitions.PROPERTIES_HANDLE properties, c_amqpvalue.AMQP_VALUE properties_amqp_value,
     c_amqpvalue.AMQP_VALUE application_properties, c_amqpvalue.AMQP_VALUE application_properties_value,
     c_amqpvalue.AMQP_VALUE body_amqp_value):
@@ -379,6 +380,12 @@ cdef void destroy_amqp_objects_in_get_encoded_message_size(c_amqp_definitions.HE
 
     if <void*>msg_annotations != NULL:
         c_amqpvalue.amqpvalue_destroy(msg_annotations)
+
+    if <void*>footer != NULL:
+        c_amqpvalue.amqpvalue_destroy(footer)
+
+    if <void*>delivery_annotations != NULL:
+        c_amqpvalue.amqpvalue_destroy(delivery_annotations)
 
     if <void*>properties != NULL:
         c_amqp_definitions.properties_destroy(properties)
@@ -411,6 +418,8 @@ cpdef size_t get_encoded_message_size(cMessage message, encoded_data):
         cdef c_amqpvalue.AMQP_VALUE application_properties_value = <c_amqpvalue.AMQP_VALUE>NULL
         cdef c_amqpvalue.AMQP_VALUE body_amqp_value = <c_amqpvalue.AMQP_VALUE>NULL
         cdef c_amqpvalue.AMQP_VALUE msg_annotations = <c_amqpvalue.AMQP_VALUE>NULL
+        cdef c_amqpvalue.AMQP_VALUE footer = <c_amqpvalue.AMQP_VALUE>NULL
+        cdef c_amqpvalue.AMQP_VALUE delivery_annotations = <c_amqpvalue.AMQP_VALUE>NULL
         cdef c_amqpvalue.AMQP_VALUE message_body_amqp_value
         cdef c_message.BINARY_DATA binary_data
         cdef c_amqpvalue.AMQP_VALUE body_amqp_data
@@ -428,14 +437,14 @@ cpdef size_t get_encoded_message_size(cMessage message, encoded_data):
             header_amqp_value = c_amqp_definitions.amqpvalue_create_header(header)
             if <void*>header_amqp_value == NULL:
                 _logger.debug("Cannot create header AMQP value")
-                destroy_amqp_objects_in_get_encoded_message_size(header, header_amqp_value, msg_annotations,
+                destroy_amqp_objects_in_get_encoded_message_size(header, header_amqp_value, msg_annotations, footer, delivery_annotations,
                     properties, properties_amqp_value, application_properties, application_properties_value,
                     body_amqp_value)
                 raise MemoryError("Cannot get cMessage header.")
             else:
                 if c_amqpvalue.amqpvalue_get_encoded_size(header_amqp_value, &encoded_size) != 0:
                     _logger.debug("Cannot obtain header encoded size")
-                    destroy_amqp_objects_in_get_encoded_message_size(header, header_amqp_value, msg_annotations,
+                    destroy_amqp_objects_in_get_encoded_message_size(header, header_amqp_value, msg_annotations, footer, delivery_annotations,
                         properties, properties_amqp_value, application_properties, application_properties_value,
                         body_amqp_value)
                     raise ValueError("Cannot obtain header encoded size")
@@ -446,7 +455,7 @@ cpdef size_t get_encoded_message_size(cMessage message, encoded_data):
         if c_message.message_get_message_annotations(c_msg, &msg_annotations) == 0 and <void*>msg_annotations != NULL:
             if c_amqpvalue.amqpvalue_get_encoded_size(msg_annotations, &encoded_size) != 0:
                 _logger.debug("Cannot obtain message annotations encoded size")
-                destroy_amqp_objects_in_get_encoded_message_size(header, header_amqp_value, msg_annotations,
+                destroy_amqp_objects_in_get_encoded_message_size(header, header_amqp_value, msg_annotations, footer, delivery_annotations,
                     properties, properties_amqp_value, application_properties, application_properties_value,
                     body_amqp_value)
                 raise ValueError("Cannot obtain message annotations encoded size")
@@ -458,14 +467,14 @@ cpdef size_t get_encoded_message_size(cMessage message, encoded_data):
             properties_amqp_value = c_amqp_definitions.amqpvalue_create_properties(properties)
             if <void*>properties_amqp_value == NULL:
                 _logger.debug("Cannot create properties AMQP value")
-                destroy_amqp_objects_in_get_encoded_message_size(header, header_amqp_value, msg_annotations,
+                destroy_amqp_objects_in_get_encoded_message_size(header, header_amqp_value, msg_annotations, footer, delivery_annotations,
                     properties, properties_amqp_value, application_properties, application_properties_value,
                     body_amqp_value)
                 raise MemoryError("Cannot get cMessage properties.")
             else:
                 if c_amqpvalue.amqpvalue_get_encoded_size(properties_amqp_value, &encoded_size) != 0:
                     _logger.debug("Cannot obtain message properties encoded size")
-                    destroy_amqp_objects_in_get_encoded_message_size(header, header_amqp_value, msg_annotations,
+                    destroy_amqp_objects_in_get_encoded_message_size(header, header_amqp_value, msg_annotations, footer, delivery_annotations,
                         properties, properties_amqp_value, application_properties, application_properties_value,
                         body_amqp_value)
                     raise ValueError("Cannot obtain message properties encoded size")
@@ -477,37 +486,59 @@ cpdef size_t get_encoded_message_size(cMessage message, encoded_data):
             application_properties_value = c_amqp_definitions.amqpvalue_create_application_properties(application_properties)
             if <void*>application_properties_value == NULL:
                 _logger.debug("Cannot create application properties AMQP value")
-                destroy_amqp_objects_in_get_encoded_message_size(header, header_amqp_value, msg_annotations,
+                destroy_amqp_objects_in_get_encoded_message_size(header, header_amqp_value, msg_annotations, footer, delivery_annotations,
                     properties, properties_amqp_value, application_properties, application_properties_value,
                     body_amqp_value)
                 raise MemoryError("Cannot get cMessage application properties.")
             else:
                 if c_amqpvalue.amqpvalue_get_encoded_size(application_properties_value, &encoded_size) != 0:
                     _logger.debug("Cannot obtain application properties encoded size")
-                    destroy_amqp_objects_in_get_encoded_message_size(header, header_amqp_value, msg_annotations,
+                    destroy_amqp_objects_in_get_encoded_message_size(header, header_amqp_value, msg_annotations, footer, delivery_annotations,
                         properties, properties_amqp_value, application_properties, application_properties_value,
                         body_amqp_value)
                     raise ValueError("Cannot obtain application properties encoded size")
                 else:
                     total_encoded_size += encoded_size
 
+        # footer
+        if c_message.message_get_footer(c_msg, &footer) == 0 and <void*>footer != NULL:
+            if c_amqpvalue.amqpvalue_get_encoded_size(footer, &encoded_size) != 0:
+                _logger.debug("Cannot obtain footer encoded size")
+                destroy_amqp_objects_in_get_encoded_message_size(header, header_amqp_value, msg_annotations, footer, delivery_annotations,
+                    properties, properties_amqp_value, application_properties, application_properties_value,
+                    body_amqp_value)
+                raise ValueError("Cannot obtain footer encoded size")
+            else:
+                total_encoded_size += encoded_size
+
+        # delivery annotations
+        if c_message.message_get_delivery_annotations(c_msg, &delivery_annotations) == 0 and <void*>delivery_annotations != NULL:
+            if c_amqpvalue.amqpvalue_get_encoded_size(delivery_annotations, &encoded_size) != 0:
+                _logger.debug("Cannot obtain delivery annotations encoded size")
+                destroy_amqp_objects_in_get_encoded_message_size(header, header_amqp_value, msg_annotations, footer, delivery_annotations,
+                    properties, properties_amqp_value, application_properties, application_properties_value,
+                    body_amqp_value)
+                raise ValueError("Cannot obtain delivery annotations encoded size")
+            else:
+                total_encoded_size += encoded_size
+
         # value body
         if message_body_type == c_message.MESSAGE_BODY_TYPE_TAG.MESSAGE_BODY_TYPE_VALUE:
             if c_message.message_get_body_amqp_value_in_place(c_msg, &message_body_amqp_value) != 0:
-                destroy_amqp_objects_in_get_encoded_message_size(header, header_amqp_value, msg_annotations,
+                destroy_amqp_objects_in_get_encoded_message_size(header, header_amqp_value, msg_annotations, footer, delivery_annotations,
                     properties, properties_amqp_value, application_properties, application_properties_value,
                     body_amqp_value)
                 raise ValueError("Cannot obtain AMQP value from body")
             body_amqp_value = c_amqp_definitions.amqpvalue_create_amqp_value(message_body_amqp_value)
             if <void*>body_amqp_value == NULL:
-                destroy_amqp_objects_in_get_encoded_message_size(header, header_amqp_value, msg_annotations,
+                destroy_amqp_objects_in_get_encoded_message_size(header, header_amqp_value, msg_annotations, footer, delivery_annotations,
                     properties, properties_amqp_value, application_properties, application_properties_value,
                     body_amqp_value)
                 raise MemoryError("Cannot create body AMQP value")
             else:
                 if c_amqpvalue.amqpvalue_get_encoded_size(body_amqp_value, &encoded_size) != 0:
                     _logger.debug("Cannot get body AMQP value encoded size")
-                    destroy_amqp_objects_in_get_encoded_message_size(header, header_amqp_value, msg_annotations,
+                    destroy_amqp_objects_in_get_encoded_message_size(header, header_amqp_value, msg_annotations, footer, delivery_annotations,
                         properties, properties_amqp_value, application_properties, application_properties_value,
                         body_amqp_value)
                     raise ValueError("Cannot get body AMQP value encoded size")
@@ -517,18 +548,18 @@ cpdef size_t get_encoded_message_size(cMessage message, encoded_data):
         # data body
         if message_body_type == c_message.MESSAGE_BODY_TYPE_TAG.MESSAGE_BODY_TYPE_DATA:
             if c_message.message_get_body_amqp_data_count(c_msg, &body_data_count) != 0:
-                destroy_amqp_objects_in_get_encoded_message_size(header, header_amqp_value, msg_annotations,
+                destroy_amqp_objects_in_get_encoded_message_size(header, header_amqp_value, msg_annotations, footer, delivery_annotations,
                     properties, properties_amqp_value, application_properties, application_properties_value,
                     body_amqp_value)
                 raise ValueError("Cannot get body AMQP data count")
             if body_data_count == 0:
-                destroy_amqp_objects_in_get_encoded_message_size(header, header_amqp_value, msg_annotations,
+                destroy_amqp_objects_in_get_encoded_message_size(header, header_amqp_value, msg_annotations, footer, delivery_annotations,
                     properties, properties_amqp_value, application_properties, application_properties_value,
                     body_amqp_value)
                 raise ValueError("Body data count is zero")
             for i in range(body_data_count):
                 if c_message.message_get_body_amqp_data_in_place(c_msg, i, &binary_data) != 0:
-                    destroy_amqp_objects_in_get_encoded_message_size(header, header_amqp_value, msg_annotations,
+                    destroy_amqp_objects_in_get_encoded_message_size(header, header_amqp_value, msg_annotations, footer, delivery_annotations,
                         properties, properties_amqp_value, application_properties, application_properties_value,
                         body_amqp_value)
                     raise ValueError("Cannot get body AMQP data {}".format(i))
@@ -537,14 +568,14 @@ cpdef size_t get_encoded_message_size(cMessage message, encoded_data):
                 binary_value.length = <stdint.uint32_t>binary_data.length
                 body_amqp_data = c_amqp_definitions.amqpvalue_create_data(binary_value)
                 if <void*>body_amqp_data == NULL:
-                    destroy_amqp_objects_in_get_encoded_message_size(header, header_amqp_value, msg_annotations,
+                    destroy_amqp_objects_in_get_encoded_message_size(header, header_amqp_value, msg_annotations, footer, delivery_annotations,
                         properties, properties_amqp_value, application_properties, application_properties_value,
                         body_amqp_value)
                     raise MemoryError("Cannot create body AMQP data")
                 else:
                     if c_amqpvalue.amqpvalue_get_encoded_size(body_amqp_data, &encoded_size) != 0:
                         _logger.debug("Cannot get body AMQP data encoded size")
-                        destroy_amqp_objects_in_get_encoded_message_size(header, header_amqp_value, msg_annotations,
+                        destroy_amqp_objects_in_get_encoded_message_size(header, header_amqp_value, msg_annotations, footer, delivery_annotations,
                             properties, properties_amqp_value, application_properties, application_properties_value,
                             body_amqp_value)
                         c_amqpvalue.amqpvalue_destroy(body_amqp_data)
@@ -559,7 +590,7 @@ cpdef size_t get_encoded_message_size(cMessage message, encoded_data):
                     header_amqp_value,
                     <c_amqpvalue.AMQPVALUE_ENCODER_OUTPUT>encode_bytes_callback,
                     <void*>encoded_data) != 0:
-                destroy_amqp_objects_in_get_encoded_message_size(header, header_amqp_value, msg_annotations,
+                destroy_amqp_objects_in_get_encoded_message_size(header, header_amqp_value, msg_annotations, footer, delivery_annotations,
                     properties, properties_amqp_value, application_properties, application_properties_value,
                     body_amqp_value)
                 raise ValueError("Cannot encode header value")
@@ -568,7 +599,7 @@ cpdef size_t get_encoded_message_size(cMessage message, encoded_data):
                     msg_annotations,
                     <c_amqpvalue.AMQPVALUE_ENCODER_OUTPUT>encode_bytes_callback,
                     <void*>encoded_data) != 0:
-                destroy_amqp_objects_in_get_encoded_message_size(header, header_amqp_value, msg_annotations,
+                destroy_amqp_objects_in_get_encoded_message_size(header, header_amqp_value, msg_annotations, footer, delivery_annotations,
                     properties, properties_amqp_value, application_properties, application_properties_value,
                     body_amqp_value)
                 raise ValueError("Cannot encode message annotations value")
@@ -577,7 +608,7 @@ cpdef size_t get_encoded_message_size(cMessage message, encoded_data):
                     properties_amqp_value,
                     <c_amqpvalue.AMQPVALUE_ENCODER_OUTPUT>encode_bytes_callback,
                     <void*>encoded_data) != 0:
-                destroy_amqp_objects_in_get_encoded_message_size(header, header_amqp_value, msg_annotations,
+                destroy_amqp_objects_in_get_encoded_message_size(header, header_amqp_value, msg_annotations, footer, delivery_annotations,
                     properties, properties_amqp_value, application_properties, application_properties_value,
                     body_amqp_value)
                 raise ValueError("Cannot encode message properties value")
@@ -586,23 +617,41 @@ cpdef size_t get_encoded_message_size(cMessage message, encoded_data):
                     application_properties_value,
                     <c_amqpvalue.AMQPVALUE_ENCODER_OUTPUT>encode_bytes_callback,
                     <void*>encoded_data) != 0:
-                destroy_amqp_objects_in_get_encoded_message_size(header, header_amqp_value, msg_annotations,
+                destroy_amqp_objects_in_get_encoded_message_size(header, header_amqp_value, msg_annotations, footer, delivery_annotations,
                     properties, properties_amqp_value, application_properties, application_properties_value,
                     body_amqp_value)
                 raise ValueError("Cannot encode application properties value")
+        if <void*>footer != NULL:
+            if c_amqpvalue.amqpvalue_encode(
+                    footer,
+                    <c_amqpvalue.AMQPVALUE_ENCODER_OUTPUT>encode_bytes_callback,
+                    <void*>encoded_data) != 0:
+                destroy_amqp_objects_in_get_encoded_message_size(header, header_amqp_value, msg_annotations, footer, delivery_annotations,
+                    properties, properties_amqp_value, application_properties, application_properties_value,
+                    body_amqp_value)
+                raise ValueError("Cannot encode footer value")
+        if <void*>delivery_annotations != NULL:
+            if c_amqpvalue.amqpvalue_encode(
+                    delivery_annotations,
+                    <c_amqpvalue.AMQPVALUE_ENCODER_OUTPUT>encode_bytes_callback,
+                    <void*>encoded_data) != 0:
+                destroy_amqp_objects_in_get_encoded_message_size(header, header_amqp_value, msg_annotations, footer, delivery_annotations,
+                    properties, properties_amqp_value, application_properties, application_properties_value,
+                    body_amqp_value)
+                raise ValueError("Cannot encode delivery annotations value")
         if message_body_type == c_message.MESSAGE_BODY_TYPE_TAG.MESSAGE_BODY_TYPE_VALUE:
             if c_amqpvalue.amqpvalue_encode(
                     body_amqp_value,
                     <c_amqpvalue.AMQPVALUE_ENCODER_OUTPUT>encode_bytes_callback,
                     <void*>encoded_data) != 0:
-                destroy_amqp_objects_in_get_encoded_message_size(header, header_amqp_value, msg_annotations,
+                destroy_amqp_objects_in_get_encoded_message_size(header, header_amqp_value, msg_annotations, footer, delivery_annotations,
                     properties, properties_amqp_value, application_properties, application_properties_value,
                     body_amqp_value)
                 raise ValueError("Cannot encode body AMQP value")
         if message_body_type == c_message.MESSAGE_BODY_TYPE_TAG.MESSAGE_BODY_TYPE_DATA:
             for i in range(body_data_count):
                 if c_message.message_get_body_amqp_data_in_place(c_msg, i, &binary_data) != 0:
-                    destroy_amqp_objects_in_get_encoded_message_size(header, header_amqp_value, msg_annotations,
+                    destroy_amqp_objects_in_get_encoded_message_size(header, header_amqp_value, msg_annotations, footer, delivery_annotations,
                         properties, properties_amqp_value, application_properties, application_properties_value,
                         body_amqp_value)
                     raise ValueError("Cannot get body AMQP data {}".format(i))
@@ -611,7 +660,7 @@ cpdef size_t get_encoded_message_size(cMessage message, encoded_data):
                 binary_value.length = <stdint.uint32_t>binary_data.length
                 body_amqp_data = c_amqp_definitions.amqpvalue_create_data(binary_value)
                 if <void*>body_amqp_data == NULL:
-                    destroy_amqp_objects_in_get_encoded_message_size(header, header_amqp_value, msg_annotations,
+                    destroy_amqp_objects_in_get_encoded_message_size(header, header_amqp_value, msg_annotations, footer, delivery_annotations,
                         properties, properties_amqp_value, application_properties, application_properties_value,
                         body_amqp_value)
                     raise MemoryError("Cannot create body AMQP data")
@@ -620,14 +669,14 @@ cpdef size_t get_encoded_message_size(cMessage message, encoded_data):
                             body_amqp_data,
                             <c_amqpvalue.AMQPVALUE_ENCODER_OUTPUT>encode_bytes_callback,
                             <void*>encoded_data) != 0:
-                        destroy_amqp_objects_in_get_encoded_message_size(header, header_amqp_value, msg_annotations,
+                        destroy_amqp_objects_in_get_encoded_message_size(header, header_amqp_value, msg_annotations, footer, delivery_annotations,
                             properties, properties_amqp_value, application_properties, application_properties_value,
                             body_amqp_value)
                         c_amqpvalue.amqpvalue_destroy(body_amqp_data)
                         raise ValueError("Cannot encode body AMQP value")
                     c_amqpvalue.amqpvalue_destroy(body_amqp_data)
 
-        destroy_amqp_objects_in_get_encoded_message_size(header, header_amqp_value, msg_annotations,
+        destroy_amqp_objects_in_get_encoded_message_size(header, header_amqp_value, msg_annotations, footer, delivery_annotations,
             properties, properties_amqp_value, application_properties, application_properties_value,
             body_amqp_value)
 

--- a/src/vendor/azure-uamqp-c/src/message_sender.c
+++ b/src/vendor/azure-uamqp-c/src/message_sender.c
@@ -656,7 +656,7 @@ static SEND_ONE_MESSAGE_RESULT send_one_message(MESSAGE_SENDER_INSTANCE* message
             annotations_destroy(footer);
         }
 
-        if (delivery_annotations != NULL);
+        if (delivery_annotations != NULL)
         {
             annotations_destroy(delivery_annotations);
         }

--- a/src/vendor/azure-uamqp-c/src/message_sender.c
+++ b/src/vendor/azure-uamqp-c/src/message_sender.c
@@ -208,6 +208,8 @@ static SEND_ONE_MESSAGE_RESULT send_one_message(MESSAGE_SENDER_INSTANCE* message
         AMQP_VALUE body_amqp_value = NULL;
         size_t body_data_count = 0;
         AMQP_VALUE msg_annotations = NULL;
+        AMQP_VALUE footer = NULL;
+        AMQP_VALUE delivery_annotations = NULL;
         bool is_error = false;
 
         // message header
@@ -298,6 +300,38 @@ static SEND_ONE_MESSAGE_RESULT send_one_message(MESSAGE_SENDER_INSTANCE* message
                 {
                     total_encoded_size += encoded_size;
                 }
+            }
+        }
+
+        // footer
+        if ((!is_error) &&
+            (message_get_footer(message, &footer) == 0) &&
+            (footer != NULL))
+        {
+            if (amqpvalue_get_encoded_size(footer, &encoded_size) != 0)
+            {
+                LogError("Cannot obtain footer encoded size");
+                is_error = true;
+            }
+            else
+            {
+                total_encoded_size += encoded_size;
+            }
+        }
+
+        // delivery annotations
+        if ((!is_error) &&
+            (message_get_delivery_annotations(message, &delivery_annotations) == 0) &&
+            (delivery_annotations != NULL))
+        {
+            if (amqpvalue_get_encoded_size(delivery_annotations, &encoded_size) != 0)
+            {
+                LogError("Cannot obtain delivery annotations encoded size");
+                is_error = true;
+            }
+            else
+            {
+                total_encoded_size += encoded_size;
             }
         }
 
@@ -462,6 +496,28 @@ static SEND_ONE_MESSAGE_RESULT send_one_message(MESSAGE_SENDER_INSTANCE* message
                     log_message_chunk(message_sender, "Application properties:", application_properties_value);
                 }
 
+                if ((result == SEND_ONE_MESSAGE_OK) && (footer != NULL))
+                {
+                    if (amqpvalue_encode(footer, encode_bytes, &payload) != 0)
+                    {
+                        LogError("Cannot encode footer value");
+                        result = SEND_ONE_MESSAGE_ERROR;
+                    }
+
+                    log_message_chunk(message_sender, "Footer:", footer);
+                }
+
+                if ((result == SEND_ONE_MESSAGE_OK) && (delivery_annotations != NULL))
+                {
+                    if (amqpvalue_encode(delivery_annotations, encode_bytes, &payload) != 0)
+                    {
+                        LogError("Cannot encode delivery annotations value");
+                        result = SEND_ONE_MESSAGE_ERROR;
+                    }
+
+                    log_message_chunk(message_sender, "Delivery annotations:", delivery_annotations);
+                }
+
                 if (result == SEND_ONE_MESSAGE_OK)
                 {
                     switch (message_body_type)
@@ -593,6 +649,16 @@ static SEND_ONE_MESSAGE_RESULT send_one_message(MESSAGE_SENDER_INSTANCE* message
         if (properties != NULL)
         {
             properties_destroy(properties);
+        }
+
+        if (footer != NULL)
+        {
+            annotations_destroy(footer);
+        }
+
+        if (delivery_annotations != NULL);
+        {
+            annotations_destroy(delivery_annotations);
         }
     }
 

--- a/uamqp/__init__.py
+++ b/uamqp/__init__.py
@@ -35,7 +35,7 @@ except (SyntaxError, ImportError):
     pass  # Async not supported.
 
 
-__version__ = "1.2.10"
+__version__ = "1.2.11"
 
 
 _logger = logging.getLogger(__name__)

--- a/uamqp/message.py
+++ b/uamqp/message.py
@@ -278,8 +278,21 @@ class Message(object):
             ann_props = c_uamqp.create_message_annotations(
                 utils.data_factory(self.annotations, encoding=self._encoding))
             c_message.message_annotations = ann_props
+        if self.delivery_annotations:
+            if not isinstance(self.delivery_annotations, dict):
+                raise TypeError("Delivery annotations must be a dictionary.")
+            delivery_ann_props = c_uamqp.create_delivery_annotations(
+                utils.data_factory(self.delivery_annotations, encoding=self._encoding))
+            c_message.delivery_annotations = delivery_ann_props
         if self.header:
             c_message.header = self.header.get_header_obj()
+        if self.footer:
+            if not isinstance(self.footer, dict):
+                raise TypeError("Footer must be a dictionary.")
+            footer = c_uamqp.create_footer(
+                utils.data_factory(self.footer, encoding=self._encoding))
+            c_message.footer = footer
+
 
     @property
     def settled(self):


### PR DESCRIPTION
This PR fixes the issue https://github.com/Azure/azure-uamqp-python/issues/169 that footer and annotation_delivery not being encoded into the outgoing payload.
