### PR TITLE
prevent receiver from receiving messages during connection establishment

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -9,6 +9,7 @@ Release History
 - Fixed bug in accessing `MessageProperties.user_id` triggering segmentation fault when the underlying C bytes are NULL.
 - Fixed bug in `MessageProperties.user_id` being limited to 8 bytes.
 - Fixed bug that macOS was unable to detect network error.
+- Fixed bug that `ReceiveClient` and `ReceiveClientAsync` receive messages during connection establishment.
 
 1.2.12 (2020-10-09)
 +++++++++++++++++++

--- a/samples/asynctests/test_azure_event_hubs_receive_async.py
+++ b/samples/asynctests/test_azure_event_hubs_receive_async.py
@@ -107,24 +107,32 @@ async def test_event_hubs_callback_async_receive_no_shutdown_after_timeout(live_
 
     receive_client = uamqp.ReceiveClientAsync(source, auth=sas_auth, timeout=3000, prefetch=10, shutdown_after_timeout=False)
     log.info("Created client, receiving...")
+    try:
+        await receive_client.open_async()
+        while not await receive_client.client_ready_async():
+            await asyncio.sleep(0.05)
 
-    await receive_client.open_async()
-    while not await receive_client.client_ready_async():
-        await receive_client.do_work_async()
+        await asyncio.sleep(1)  # sleep for 1s
+        await receive_client._connection.work_async()  # do a single connection iteration to see if there're incoming transfers
 
-    send_single_message(live_eventhub_config, live_eventhub_config['partition'], 'message')
-    await receive_client.receive_messages_async(on_message_received_internal)
-    message_handler_before = receive_client.message_handler
-    assert received_cnt['cnt'] == 1
+        # make sure no messages are received
+        assert not receive_client._was_message_received
+        assert receive_client._received_messages.empty()
 
-    send_single_message(live_eventhub_config, live_eventhub_config['partition'], 'message')
-    await receive_client.receive_messages_async(on_message_received_internal)
-    message_handler_after = receive_client.message_handler
-    assert message_handler_before == message_handler_after
-    assert received_cnt['cnt'] == 2
+        send_single_message(live_eventhub_config, live_eventhub_config['partition'], 'message')
+        await receive_client.receive_messages_async(on_message_received_internal)
+        message_handler_before = receive_client.message_handler
+        assert received_cnt['cnt'] == 1
 
-    log.info("Finished receiving")
-    await receive_client.close_async()
+        send_single_message(live_eventhub_config, live_eventhub_config['partition'], 'message')
+        await receive_client.receive_messages_async(on_message_received_internal)
+        message_handler_after = receive_client.message_handler
+        assert message_handler_before == message_handler_after
+        assert received_cnt['cnt'] == 2
+
+        log.info("Finished receiving")
+    finally:
+        await receive_client.close_async()
 
 
 @pytest.mark.asyncio
@@ -191,36 +199,43 @@ async def test_event_hubs_iter_receive_no_shutdown_after_timeout_async(live_even
     source.set_filter(b"amqp.annotation.x-opt-offset > '@latest'")
     receive_client = uamqp.ReceiveClientAsync(source, auth=sas_auth, timeout=2000, debug=False, shutdown_after_timeout=False)
     count = 0
+    try:
+        await receive_client.open_async()
+        while not await receive_client.client_ready_async():
+            await asyncio.sleep(0.05)
 
-    await receive_client.open_async()
-    while not await receive_client.client_ready_async():
-        await receive_client.do_work_async()
+        await asyncio.sleep(1)  # sleep for 1s
+        await receive_client._connection.work_async()  # do a single connection iteration to see if there're incoming transfers
 
-    gen = receive_client.receive_messages_iter_async()
-    send_single_message(live_eventhub_config, live_eventhub_config['partition'], 'message')
-    async for message in gen:
-        log.info(message.annotations.get(b'x-opt-sequence-number'))
-        log.info(str(message))
-        count += 1
+        # make sure no messages are received
+        assert not receive_client._was_message_received
+        assert receive_client._received_messages.empty()
 
-    assert count == 1
-    count = 0
+        gen = receive_client.receive_messages_iter_async()
+        send_single_message(live_eventhub_config, live_eventhub_config['partition'], 'message')
+        async for message in gen:
+            log.info(message.annotations.get(b'x-opt-sequence-number'))
+            log.info(str(message))
+            count += 1
 
-    message_handler_before = receive_client.message_handler
-    send_single_message(live_eventhub_config, live_eventhub_config['partition'], 'message')
-    gen = receive_client.receive_messages_iter_async()
+        assert count == 1
+        count = 0
 
-    async for message in gen:
-        log.info(message.annotations.get(b'x-opt-sequence-number'))
-        log.info(str(message))
-        count += 1
+        message_handler_before = receive_client.message_handler
+        send_single_message(live_eventhub_config, live_eventhub_config['partition'], 'message')
+        gen = receive_client.receive_messages_iter_async()
 
-    assert count == 1
+        async for message in gen:
+            log.info(message.annotations.get(b'x-opt-sequence-number'))
+            log.info(str(message))
+            count += 1
 
-    message_handler_after = receive_client.message_handler
-    assert message_handler_before == message_handler_after
+        assert count == 1
 
-    await receive_client.close_async()
+        message_handler_after = receive_client.message_handler
+        assert message_handler_before == message_handler_after
+    finally:
+        await receive_client.close_async()
 
 @pytest.mark.asyncio
 async def test_event_hubs_batch_receive_async(live_eventhub_config):
@@ -432,6 +447,13 @@ async def test_event_hubs_dynamic_issue_link_credit_async(live_eventhub_config):
         while not await receive_client.client_ready_async():
             await asyncio.sleep(0.05)
 
+        await asyncio.sleep(1)  # sleep for 1s
+        await receive_client._connection.work_async()  # do a single connection iteration to see if there're incoming transfers
+
+        # make sure no messages are received
+        assert not receive_client._was_message_received
+        assert receive_client._received_messages.empty()
+
         await receive_client.message_handler.reset_link_credit_async(msg_sent_cnt)
 
         now = start = time.time()
@@ -444,6 +466,37 @@ async def test_event_hubs_dynamic_issue_link_credit_async(live_eventhub_config):
         log.info("Finished receiving")
 
 
+@pytest.mark.asyncio
+async def test_event_hubs_not_receive_events_during_connection_establishment_async(live_eventhub_config):
+    uri = "sb://{}/{}".format(live_eventhub_config['hostname'], live_eventhub_config['event_hub'])
+    sas_auth = authentication.SASTokenAsync.from_shared_access_key(
+        uri, live_eventhub_config['key_name'], live_eventhub_config['access_key'])
+    source = "amqps://{}/{}/ConsumerGroups/{}/Partitions/{}".format(
+        live_eventhub_config['hostname'],
+        live_eventhub_config['event_hub'],
+        live_eventhub_config['consumer_group'],
+        live_eventhub_config['partition'])
+
+    receive_client = uamqp.ReceiveClientAsync(source, auth=sas_auth, timeout=1000, debug=False, prefetch=10)
+    try:
+        await receive_client.open_async()
+
+        while not await receive_client.client_ready_async():
+            await asyncio.sleep(0.05)
+
+        await asyncio.sleep(1)  # sleep for 1s
+        await receive_client._connection.work_async()  # do a single connection iteration to see if there're incoming transfers
+
+        # make sure no messages are received
+        assert not receive_client._was_message_received
+        assert receive_client._received_messages.empty()
+
+        messages_0 = await receive_client.receive_message_batch_async()
+        assert len(messages_0) > 0
+    finally:
+        await receive_client.close_async()
+
+
 if __name__ == '__main__':
     config = {}
     config['hostname'] = os.environ['EVENT_HUB_HOSTNAME']
@@ -454,4 +507,4 @@ if __name__ == '__main__':
     config['partition'] = "0"
 
     loop = asyncio.get_event_loop()
-    loop.run_until_complete(test_event_hubs_batch_receive_async_no_shutdown_after_timeout_sync(config))
+    loop.run_until_complete(test_event_hubs_not_receive_events_during_connection_establishment_async(config))

--- a/samples/asynctests/test_azure_event_hubs_receive_async.py
+++ b/samples/asynctests/test_azure_event_hubs_receive_async.py
@@ -197,7 +197,7 @@ async def test_event_hubs_iter_receive_no_shutdown_after_timeout_async(live_even
 
     source = address.Source(source)
     source.set_filter(b"amqp.annotation.x-opt-offset > '@latest'")
-    receive_client = uamqp.ReceiveClientAsync(source, auth=sas_auth, timeout=2000, debug=False, shutdown_after_timeout=False)
+    receive_client = uamqp.ReceiveClientAsync(source, auth=sas_auth, timeout=5000, debug=False, shutdown_after_timeout=False)
     count = 0
     try:
         await receive_client.open_async()

--- a/uamqp/async_ops/client_async.py
+++ b/uamqp/async_ops/client_async.py
@@ -809,7 +809,7 @@ class ReceiveClientAsync(client.ReceiveClient, AMQPClientAsync):
                 debug=self._debug_trace,
                 receive_settle_mode=self._receive_settle_mode,
                 send_settle_mode=self._send_settle_mode,
-                prefetch=self._prefetch,
+                prefetch=0,  # set to 0 as not to receive messages during connection establishment, set prefetch later
                 max_message_size=self._max_message_size,
                 properties=self._link_properties,
                 error_policy=self._error_policy,
@@ -826,6 +826,8 @@ class ReceiveClientAsync(client.ReceiveClient, AMQPClientAsync):
         if self.message_handler.get_state() != constants.MessageReceiverState.Open:
             self._last_activity_timestamp = self._counter.get_current_ms()
             return False
+        # once the receiver client is ready/connection established, we set prefetch as per the config
+        self.message_handler._link.set_prefetch_count(self._prefetch)  # pylint: disable=protected-access
         return True
 
     async def _client_run_async(self):

--- a/uamqp/client.py
+++ b/uamqp/client.py
@@ -923,7 +923,7 @@ class ReceiveClient(AMQPClient):
                 debug=self._debug_trace,
                 receive_settle_mode=self._receive_settle_mode,
                 send_settle_mode=self._send_settle_mode,
-                prefetch=self._prefetch,
+                prefetch=0,  # set to 0 as not to receive messages during connection establishment, set prefetch later
                 max_message_size=self._max_message_size,
                 properties=self._link_properties,
                 error_policy=self._error_policy,
@@ -939,6 +939,9 @@ class ReceiveClient(AMQPClient):
         if self.message_handler.get_state() != constants.MessageReceiverState.Open:
             self._last_activity_timestamp = self._counter.get_current_ms()
             return False
+
+        # once the receiver client is ready/connection established, we set prefetch as per the config
+        self.message_handler._link.set_prefetch_count(self._prefetch)  # pylint: disable=protected-access
         return True
 
     def _client_run(self):

--- a/uamqp/receiver.py
+++ b/uamqp/receiver.py
@@ -105,7 +105,7 @@ class MessageReceiver(object):
         self._session = session
         self._link = c_uamqp.create_link(session._session, self.name, role.value, self.source, self.target)
         self._link.subscribe_to_detach_event(self)
-        if prefetch:
+        if prefetch is not None:
             self._link.set_prefetch_count(prefetch)
         if properties:
             self._link.set_attach_properties(utils.data_factory(properties, encoding=encoding))


### PR DESCRIPTION
prevent receiver from receiving messages during connection establishment
addressing issue: https://github.com/Azure/azure-sdk-for-python/issues/15555
moving the fix of https://github.com/Azure/azure-sdk-for-python/pull/15622 into uamqp
