### PR TITLE
Fix broken get-pip call in Install Dependencies step

### DIFF
--- a/.azure-pipelines/client.yml
+++ b/.azure-pipelines/client.yml
@@ -8,6 +8,7 @@ variables:
   PythonVersion37: '3.7'
   PythonVersion38: '3.8'
   PythonVersion39: '3.9'
+  GetPip: 'https://bootstrap.pypa.io/get-pip.py'
 
 jobs:
   - job: 'sdist'
@@ -28,7 +29,8 @@ jobs:
 
       - script: |
           python --version
-          curl -sS https://bootstrap.pypa.io/get-pip.py | python - --user
+          curl -sS $(GetPip) | python - --user
+          python -m pip --version
           python -m pip install --user -r dev_requirements.txt
         displayName: 'Install dependencies'
       - script: python setup.py sdist
@@ -53,9 +55,11 @@ jobs:
         Python 2.7:
           PythonBin: 'python2'
           PythonVersion: '$(PythonVersion27)'
+          GetPip: 'https://bootstrap.pypa.io/2.7/get-pip.py'
         Python 3.5:
           PythonBin: 'python3'
           PythonVersion: '$(PythonVersion35)'
+          GetPip: 'https://bootstrap.pypa.io/3.5/get-pip.py'
         Python 3.6:
           PythonBin: 'python3'
           PythonVersion: '$(PythonVersion36)'
@@ -106,7 +110,8 @@ jobs:
 
       - script: |
           $(PythonBin) --version
-          curl -sS https://bootstrap.pypa.io/get-pip.py | $(PythonBin) - --user
+          curl -sS $(GetPip) | $(PythonBin) - --user
+          $(PythonBin) -m pip --version
           $(PythonBin) -m pip install --user -r dev_requirements.txt
         displayName: 'Install dependencies'
 
@@ -156,9 +161,11 @@ jobs:
         x64 Python 2.7:
           PythonArchitecture: 'x64'
           PythonVersion: '$(PythonVersion27)'
+          GetPip: 'https://bootstrap.pypa.io/2.7/get-pip.py'
         x64 Python 3.5:
           PythonArchitecture: 'x64'
           PythonVersion: '$(PythonVersion35)'
+          GetPip: 'https://bootstrap.pypa.io/3.5/get-pip.py'
         x64 Python 3.6:
           PythonArchitecture: 'x64'
           PythonVersion: '$(PythonVersion36)'
@@ -174,9 +181,11 @@ jobs:
         x86 Python 2.7:
           PythonArchitecture: 'x86'
           PythonVersion: '$(PythonVersion27)'
+          GetPip: 'https://bootstrap.pypa.io/2.7/get-pip.py'
         x86 Python 3.5:
           PythonArchitecture: 'x86'
           PythonVersion: '$(PythonVersion35)'
+          GetPip: 'https://bootstrap.pypa.io/3.5/get-pip.py'
         x86 Python 3.6:
           PythonArchitecture: 'x86'
           PythonVersion: '$(PythonVersion36)'
@@ -205,7 +214,8 @@ jobs:
 
       - powershell: |
           python --version
-          Invoke-WebRequest -UseBasicParsing -Uri https://bootstrap.pypa.io/get-pip.py | Select-Object -ExpandProperty Content | python
+          Invoke-WebRequest -UseBasicParsing -Uri $(GetPip) | Select-Object -ExpandProperty Content | python
+          python -m pip --version
           python -m pip install -r dev_requirements.txt
         displayName: 'Install dependencies'
         env:
@@ -249,8 +259,10 @@ jobs:
       matrix:
         Python 2.7:
           PythonVersion: '$(PythonVersion27)'
+          GetPip: 'https://bootstrap.pypa.io/2.7/get-pip.py'
         Python 3.5:
           PythonVersion: '$(PythonVersion35)'
+          GetPip: 'https://bootstrap.pypa.io/3.5/get-pip.py'
         Python 3.6:
           PythonVersion: '$(PythonVersion36)'
         Python 3.7:
@@ -272,7 +284,8 @@ jobs:
 
       - script: |
           python --version
-          curl -sS https://bootstrap.pypa.io/get-pip.py | python - --user
+          curl -sS $(GetPip) | python - --user
+          python -m pip --version
           python -m pip install --user -r dev_requirements.txt
         displayName: 'Install dependencies'
 


### PR DESCRIPTION
Python 2.7 and 3.5 are deprecated, and Pip 21 no longer works with them. PyPA conveniently hosts the last working copy of the tool for each deprecated version of Python at a conventional URL, so this PR makes the URL passed `curl` to install Pip a variable.