### PR TITLE
Memory Leak Fix in Session.pyx along with two minor value factory fix

### DIFF
--- a/src/amqpvalue.pyx
+++ b/src/amqpvalue.pyx
@@ -891,7 +891,7 @@ cdef class CompositeValue(AMQPValue):
         if index >= self.size:
             raise IndexError("Index is out of range.")
         cdef c_amqpvalue.AMQP_VALUE value
-        value = c_amqpvalue.amqpvalue_get_composite_item_in_place(self._c_value, index)
+        value = c_amqpvalue.amqpvalue_get_composite_item(self._c_value, index)
         if <void*>value == NULL:
             self._value_error()
         try:

--- a/src/message.pyx
+++ b/src/message.pyx
@@ -286,10 +286,13 @@ cdef class cMessage(StructBase):
 
     cpdef get_body_sequence(self, size_t index):
         cdef c_amqpvalue.AMQP_VALUE _value
-        if c_message.message_get_body_amqp_sequence_in_place(self._c_value, index, &_value) == 0:
-            return value_factory(_value)
-        else:
+        cdef c_amqpvalue.AMQP_VALUE cloned
+        if c_message.message_get_body_amqp_sequence_in_place(self._c_value, index, &_value) != 0:
             self._value_error()
+        cloned = c_amqpvalue.amqpvalue_clone(_value)
+        if <void*>cloned == NULL:
+            self._value_error()
+        return value_factory(cloned)
 
     cpdef count_body_sequence(self):
         cdef size_t body_count

--- a/src/session.pyx
+++ b/src/session.pyx
@@ -148,4 +148,7 @@ cdef bint on_link_attached(
                 context_obj._attach_received(source_factory(wrapped_source), target_factory(wrapped_target), attach_properties, None)
         except Exception as e:
             _logger.info("Failed to process link ATTACH frame: %r", e)
+        finally:
+            c_amqpvalue.amqpvalue_destroy(cloned_source)
+            c_amqpvalue.amqpvalue_destroy(cloned_target)
     return True

--- a/src/session.pyx
+++ b/src/session.pyx
@@ -149,6 +149,8 @@ cdef bint on_link_attached(
         except Exception as e:
             _logger.info("Failed to process link ATTACH frame: %r", e)
         finally:
+            if <void*>wrapped_props != NULL:
+                c_amqpvalue.amqpvalue_destroy(wrapped_props)
             c_amqpvalue.amqpvalue_destroy(cloned_source)
             c_amqpvalue.amqpvalue_destroy(cloned_target)
     return True

--- a/src/session.pyx
+++ b/src/session.pyx
@@ -149,8 +149,6 @@ cdef bint on_link_attached(
         except Exception as e:
             _logger.info("Failed to process link ATTACH frame: %r", e)
         finally:
-            if <void*>wrapped_props != NULL:
-                c_amqpvalue.amqpvalue_destroy(wrapped_props)
             c_amqpvalue.amqpvalue_destroy(cloned_source)
             c_amqpvalue.amqpvalue_destroy(cloned_target)
     return True

--- a/src/source.pyx
+++ b/src/source.pyx
@@ -65,11 +65,13 @@ cdef class cSource(StructBase):
     @property
     def address(self):
         cdef c_amqpvalue.AMQP_VALUE _value
+        cdef c_amqpvalue.AMQP_VALUE _cloned_value
         if c_amqp_definitions.source_get_address(self._c_value, &_value) != 0:
             self._value_error("Failed to get source address")
         if <void*>_value == NULL:
             return None
-        return value_factory(_value).value
+        _cloned_value = c_amqpvalue.amqpvalue_clone(_value)
+        return value_factory(_cloned_value).value
 
     @address.setter
     def address(self, AMQPValue value):

--- a/src/source.pyx
+++ b/src/source.pyx
@@ -65,13 +65,15 @@ cdef class cSource(StructBase):
     @property
     def address(self):
         cdef c_amqpvalue.AMQP_VALUE _value
-        cdef c_amqpvalue.AMQP_VALUE _cloned_value
+        cdef c_amqpvalue.AMQP_VALUE cloned
         if c_amqp_definitions.source_get_address(self._c_value, &_value) != 0:
             self._value_error("Failed to get source address")
         if <void*>_value == NULL:
             return None
-        _cloned_value = c_amqpvalue.amqpvalue_clone(_value)
-        return value_factory(_cloned_value).value
+        cloned = c_amqpvalue.amqpvalue_clone(_value)
+        if <void*>cloned == NULL:
+            return None
+        return value_factory(cloned).value
 
     @address.setter
     def address(self, AMQPValue value):

--- a/src/target.pyx
+++ b/src/target.pyx
@@ -65,13 +65,15 @@ cdef class cTarget(StructBase):
     @property
     def address(self):
         cdef c_amqpvalue.AMQP_VALUE _value
-        cdef c_amqpvalue.AMQP_VALUE _cloned_value
+        cdef c_amqpvalue.AMQP_VALUE cloned
         if c_amqp_definitions.target_get_address(self._c_value, &_value) != 0:
             self._value_error("Failed to get target address")
         if <void*>_value == NULL:
             return None
-        _cloned_value = c_amqpvalue.amqpvalue_clone(_value)
-        return value_factory(_cloned_value).value
+        cloned = c_amqpvalue.amqpvalue_clone(_value)
+        if <void*>cloned == NULL:
+            return None
+        return value_factory(cloned).value
 
     @address.setter
     def address(self, AMQPValue value):

--- a/src/target.pyx
+++ b/src/target.pyx
@@ -65,11 +65,13 @@ cdef class cTarget(StructBase):
     @property
     def address(self):
         cdef c_amqpvalue.AMQP_VALUE _value
+        cdef c_amqpvalue.AMQP_VALUE _cloned_value
         if c_amqp_definitions.target_get_address(self._c_value, &_value) != 0:
             self._value_error("Failed to get target address")
         if <void*>_value == NULL:
             return None
-        return value_factory(_value).value
+        _cloned_value = c_amqpvalue.amqpvalue_clone(_value)
+        return value_factory(_cloned_value).value
 
     @address.setter
     def address(self, AMQPValue value):


### PR DESCRIPTION
**Problem:**
- This PR is to address the memory issue in service bus client creation: https://github.com/Azure/azure-sdk-for-python/issues/15747.

**Root cause:**

Client creation would leak memory after connection and **session** is established because 
- in `on_link_attached` callback in `session.pyx`, `cloned_source` and `cloned_target` are not destroyed.

**How to Fix:**
- destroy `cloned_source` and `cloned_target` in a `finally` block in the callback.

**More:**
- found that there're two more places in src/amqpvalue.pyx and src/message.pyx where `value_factory` are not used properly. fixed them at the same time.

**Analysis:**

- The memory leak is within the [on_link_attached in session.pyx](https://github.com/Azure/azure-uamqp-python/blob/master/src/session.pyx#L116):
  - two c AMQP_VALUE are cloned while not being destroyed:    
    - cdef c_amqpvalue.AMQP_VALUE cloned_source
    - cdef c_amqpvalue.AMQP_VALUE cloned_target
    - destroying them in the `finally` could correctly decrease the reference count
    - **however random segmentation fault will be triggered.**
- after keeping investigation into how the properties on the source/targer are used, the `address` property is returned by [source_get_address](https://github.com/Azure/azure-uamqp-python/blob/e1051ae1c8f93ed2792a852857d261a4f34b76f5/src/vendor/azure-uamqp-c/src/amqp_definitions.c#L12347) which is a *in_memory* opeartion (value not cloned, reference count doesn't + 1), that seems to be place where seg fault took place
  - it cannot be simply wrapped by the cython AMQPValue (via `value_factory`), as AMQPValue will call destroy (reference count - 1) when GC kicks in. the reference count will be incorrect at that time.
  - it should be cloned first, we have other similar codes in amqpvalue.pyx when C *_in_memory methods are called
  - after fixing this, no seg fault happens
- I further searched where value_factory methods are used and found two more places that need fix
  - the `pop` method in cdef class CompositeValue(AMQPValue)
  - the `get_body_sequence` method in cdef class cMessage

--------------

the steps I currently use:
- use valgrind to run E2E script first
- isolate the memory leak issue at different protocol level (Connection/Session/Link)
  - write separate scripts to test 1) Connection 2) Connection + Session 3) Connection + Session + Link
  -  use valgrind to run separate scripts

current investigation result:
- memory leak DOES NOT happen with the pure AMQP Connection (no Session, no Link)
- from valgrind logging, it's the list item within a described value get leaked
  - the item is instantiate by the C library
  - the item is passed upward to the cython/python layer via callbacks
  - which indicates that there could be some properties on session/link get leaked

So far the most suspicious part is within the `session.pyx`:

The cloned two AMQP value `cloned_source` and `cloned_target` in the `on_link_attached` callback defined in `session.pyx` looks like they're not destroyed.