### PR TITLE
Fix segmentation fault when sending large messages after socket is completely lost

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -3,6 +3,11 @@
 Release History
 ===============
 
+1.2.16 (Unreleased)
++++++++++++++++++++
+
+- Fixed bug that sending message of large size triggering segmentation fault when the underlying socket connection is lost.
+
 1.2.15 (2021-03-02)
 +++++++++++++++++++
 

--- a/samples/asynctests/test_azure_event_hubs_send_async.py
+++ b/samples/asynctests/test_azure_event_hubs_send_async.py
@@ -232,7 +232,7 @@ async def test_event_hubs_send_large_message_after_socket_lost(live_eventhub_con
         # or "Failure: sending socket failed. errno=104" on linux which indicates the socket is lost
         await asyncio.sleep(350)
 
-        with pytest.raises(uamqp.errors.ConnectionClose):
+        with pytest.raises(uamqp.errors.AMQPConnectionError):
             await send_client.send_message_async(uamqp.message.Message(b't'*1024*700))
     finally:
         await send_client.close_async()

--- a/samples/test_azure_event_hubs_send.py
+++ b/samples/test_azure_event_hubs_send.py
@@ -240,6 +240,30 @@ def test_event_hubs_idempotent_producer(live_eventhub_config):
     send_client.close()
 
 
+def test_event_hubs_send_large_message_after_socket_lost(live_eventhub_config):
+    uri = "sb://{}/{}".format(live_eventhub_config['hostname'], live_eventhub_config['event_hub'])
+    sas_auth = authentication.SASTokenAuth.from_shared_access_key(
+        uri, live_eventhub_config['key_name'], live_eventhub_config['access_key'])
+
+    target = "amqps://{}/{}".format(live_eventhub_config['hostname'], live_eventhub_config['event_hub'])
+    send_client = uamqp.SendClient(target, auth=sas_auth, debug=True)
+    try:
+        send_client.open()
+        while not send_client.client_ready():
+            send_client.do_work()
+        # the connection idle timeout setting on the EH service is 240s, after 240s no activity
+        # on the connection, the service would send detach to the client, the underlying socket on the client
+        # is still able to work to receive the frame.
+        # HOWEVER, after no activity on the client socket > 300s, the underlying socket would get completely lost:
+        # the socket reports "Failure: sending socket failed 10054" on windows
+        # or "Failure: sending socket failed. errno=104" on linux which indicates the socket is lost
+        time.sleep(350)
+
+        with pytest.raises(uamqp.errors.ConnectionClose):
+            send_client.send_message(uamqp.message.Message(b't'*1024*700))
+    finally:
+        send_client.close()
+
 if __name__ == '__main__':
     config = {}
     config['hostname'] = os.environ['EVENT_HUB_HOSTNAME']
@@ -249,4 +273,4 @@ if __name__ == '__main__':
     config['consumer_group'] = "$Default"
     config['partition'] = "0"
 
-    test_event_hubs_idempotent_producer(config)
+    test_event_hubs_send_large_message_after_socket_lost(config)

--- a/samples/test_azure_event_hubs_send.py
+++ b/samples/test_azure_event_hubs_send.py
@@ -259,7 +259,7 @@ def test_event_hubs_send_large_message_after_socket_lost(live_eventhub_config):
         # or "Failure: sending socket failed. errno=104" on linux which indicates the socket is lost
         time.sleep(350)
 
-        with pytest.raises(uamqp.errors.ConnectionClose):
+        with pytest.raises(uamqp.errors.AMQPConnectionError):
             send_client.send_message(uamqp.message.Message(b't'*1024*700))
     finally:
         send_client.close()

--- a/uamqp/__init__.py
+++ b/uamqp/__init__.py
@@ -35,7 +35,7 @@ except (SyntaxError, ImportError):
     pass  # Async not supported.
 
 
-__version__ = "1.2.15"
+__version__ = "1.2.16"
 
 
 _logger = logging.getLogger(__name__)

--- a/uamqp/async_ops/client_async.py
+++ b/uamqp/async_ops/client_async.py
@@ -567,6 +567,7 @@ class SendClientAsync(client.SendClient, AMQPClientAsync):
         """
         # pylint: disable=protected-access
         await self.message_handler.work_async()
+        await asyncio.shield(self._connection.work_async(), loop=self.loop)
         self._waiting_messages = 0
         async with self._pending_messages_lock:
             self._pending_messages = await self._filter_pending_async()
@@ -574,7 +575,6 @@ class SendClientAsync(client.SendClient, AMQPClientAsync):
             _logger.info("Client told to backoff - sleeping for %r seconds", self._backoff)
             await self._connection.sleep_async(self._backoff)
             self._backoff = 0
-        await asyncio.shield(self._connection.work_async(), loop=self.loop)
         return True
 
     async def redirect_async(self, redirect, auth):

--- a/uamqp/client.py
+++ b/uamqp/client.py
@@ -647,13 +647,13 @@ class SendClient(AMQPClient):
         """
         # pylint: disable=protected-access
         self.message_handler.work()
+        self._connection.work()
         self._waiting_messages = 0
         self._pending_messages = self._filter_pending()
         if self._backoff and not self._waiting_messages:
             _logger.info("Client told to backoff - sleeping for %r seconds", self._backoff)
             self._connection.sleep(self._backoff)
             self._backoff = 0
-        self._connection.work()
         return True
 
     @property

--- a/uamqp/connection.py
+++ b/uamqp/connection.py
@@ -175,7 +175,8 @@ class Connection(object):
                 _new_state = c_uamqp.ConnectionState.UNKNOWN
             self._state = _new_state
             _logger.info("Connection %r state changed from %r to %r", self.container_id, _previous_state, _new_state)
-            if _new_state == c_uamqp.ConnectionState.END and _previous_state != c_uamqp.ConnectionState.CLOSE_RCVD:
+            if (_new_state == c_uamqp.ConnectionState.END and _previous_state != c_uamqp.ConnectionState.CLOSE_RCVD) or\
+                _new_state == c_uamqp.ConnectionState.ERROR:
                 if not self._closing and not self._error:
                     _logger.info("Connection with ID %r unexpectedly in an error state. Closing: %r, Error: %r",
                                  self.container_id, self._closing, self._error)


### PR DESCRIPTION
The PR is to address EventHub issue regarding to sending large messages triggering segmentation fault after socket is complete lost: https://github.com/Azure/azure-sdk-for-python/issues/14543, https://github.com/Azure/azure-sdk-for-python/issues/13739

**ROOT CAUSE:**
- `ASYNC_OPERATION_HANDLE result` gets freed twice leading to segmentation fault in [link_transfer_async in link.c](https://github.com/Azure/azure-uamqp-python/blob/master/src/vendor/azure-uamqp-c/src/link.c#L1625) **when sending large message composed of multiple transfer frames in socket lost case**
  - ASYNC_OPERATION_HANDLE is a wrapper of delivery item, delivery denotes the operation of sending a frame
  - the **FIRST** time it's freed is when the connection state is changed from `OPENED` to `END` due to socket completely lost ("Failure: sending socket failed 10054.")
    - when the connection state changes, the endpoint's state change callback will be called
    - the callback path is `connection_set_state` -> `session->on_connection_state_changed` -> `link->on_session_state_changed`
    - finally, in link.c [on_session_state_changed](https://github.com/Azure/azure-uamqp-python/blob/master/src/vendor/azure-uamqp-c/src/link.c#L657) is called to remove all the deliveries when session is in an error status (caused by connection error status).
  - the **SECOND** time freeing the delivery handle in `link_transfer_async` triggers the segmentation fault when `session_send_transfer` results in `SESSION_SEND_TRANSFER_ERROR`.

**HOW TO FIX:**
- in Python layer, call connection.dowork() before sending message
  - connection.dowork() could detect socket error status and set session/link status to the correct error status via _set_state chain.
- The caller in Python -- SendClient/MessageSender, will be able to detect error first instead of still trying to send messages on a broken socket connection which leads to the segmentation fault.

**---------------------------------------- Advanced Topic ----------------------------------------**

**WHY SMALL MESSAGE COULD SURVIVE**
let's understand the send logic first:
- the sending execution path in C module is: link_transfer_async -> session_send_transfer -> **connection_encode_frame -> amqp_frame_codec_encode_frame -> frame_codec_encode_frame -> connection::on_bytes_encoded -> xio_send() -> saslclientio_send_async -> tlsio_schannel_send -> socketio_send**
  - the bald path will
    - run only one time if the message is composed a single transfer frame
    - **loop for payload_size/available_frame_size times to send all the transfer frames that composes the large message**
- the **FIRST** transfer frame encoding would succeed (no matter it's a message of small/big size) even when the socket is lost, because there is no real operation happening on the socket yet, so the errored status of the socket io is not reflected, see [`frame_codec_encode_frame`](https://github.com/Azure/azure-uamqp-python/blob/master/src/vendor/azure-uamqp-c/src/frame_codec.c#L555) in `frame_codec.c`. there is no return value from `on_bytes_encoded`.
- The socket error happens when real sending takes place and could be reflected after socket send executed.
- And for message composed of a single transfer, the aforementioned path is only executed once, the delivery instance doesn't get a chance to freed twice because after `link_transfer_async` is called and succeeded, the execution of the program is given back to the python layer -- to connection.do_work(), and the socket error will be detected and raised.
- it's when sending the second transfer frame of a message of large size triggering the segmentation fault (freed twice)

```python
    # in SendClient._client_run, small message won't trigger seg fault
    def _client_run(self):
        # code...
        self._pending_messages = self._filter_pending() # this method will call C module to send messages, small message could pass
        # code...
        self._connection.work()  # connection error raised
```


---------------------------------------- Code Snippets to Reproduce ----------------------------------------

```python
import uamqp
from uamqp import authentication
from datetime import datetime
import time
import logging
logging.basicConfig(level=logging.INFO, format='%(asctime)s %(name)-12s %(levelname)-8s %(message)s')

live_eventhub_config = {...}

uri = "sb://{}/{}".format(live_eventhub_config['hostname'], live_eventhub_config['event_hub'])
sas_auth = authentication.SASTokenAuth.from_shared_access_key(
    uri, live_eventhub_config['key_name'], live_eventhub_config['access_key'])

target = "amqps://{}/{}".format(live_eventhub_config['hostname'], live_eventhub_config['event_hub'])

send_client = uamqp.SendClient(target, auth=sas_auth, debug=True)
send_client.open()
while not send_client.client_ready():
    send_client.do_work()
print(datetime.now(), "send client is opened")

print(datetime.now(), 'start sleep')
time.sleep(350)
# sleep until the underlying socket io is completely lost
# On windows, the socket io reports "Failure: sending socket failed 10054."
# On linux, the socket io reports "sending socket failed. errno=104 (Connection reset by peer)."
print(datetime.now(), 'end sleep')

# big message will be split into multiple amqp frames which goes into an execution path
# different than a small message (which is composed of just one frame)
# see code: https://github.com/Azure/azure-uamqp-c/blob/master/src/session.c#L1532-L1676
message = uamqp.Message(
    b't'*1024*700
)

# seg fault happens
send_client.send_message(message)

send_client.close()
print(datetime.now(), "send client is closed")
```