### PR TITLE
use the latest get-pip url for py27 and 35

### DIFF
--- a/.azure-pipelines/client.test.live.yml
+++ b/.azure-pipelines/client.test.live.yml
@@ -24,11 +24,11 @@ jobs:
         x64 Python 2.7:
           PythonArchitecture: 'x64'
           PythonVersion: '$(PythonVersion27)'
-          GetPip: 'https://bootstrap.pypa.io/2.7/get-pip.py'
+          GetPip: 'https://bootstrap.pypa.io/pip/2.7/get-pip.py'
         x64 Python 3.5:
           PythonArchitecture: 'x64'
           PythonVersion: '$(PythonVersion35)'
-          GetPip: 'https://bootstrap.pypa.io/3.5/get-pip.py'
+          GetPip: 'https://bootstrap.pypa.io/pip/3.5/get-pip.py'
         x64 Python 3.6:
           PythonArchitecture: 'x64'
           PythonVersion: '$(PythonVersion36)'
@@ -44,11 +44,11 @@ jobs:
         x86 Python 2.7:
           PythonArchitecture: 'x86'
           PythonVersion: '$(PythonVersion27)'
-          GetPip: 'https://bootstrap.pypa.io/2.7/get-pip.py'
+          GetPip: 'https://bootstrap.pypa.io/pip/2.7/get-pip.py'
         x86 Python 3.5:
           PythonArchitecture: 'x86'
           PythonVersion: '$(PythonVersion35)'
-          GetPip: 'https://bootstrap.pypa.io/3.5/get-pip.py'
+          GetPip: 'https://bootstrap.pypa.io/pip/3.5/get-pip.py'
         x86 Python 3.6:
           PythonArchitecture: 'x86'
           PythonVersion: '$(PythonVersion36)'
@@ -139,11 +139,11 @@ jobs:
         Python 2.7:
           PythonBin: 'python2'
           PythonVersion: '$(PythonVersion27)'
-          GetPip: 'https://bootstrap.pypa.io/2.7/get-pip.py'
+          GetPip: 'https://bootstrap.pypa.io/pip/2.7/get-pip.py'
         Python 3.5:
           PythonBin: 'python3'
           PythonVersion: '$(PythonVersion35)'
-          GetPip: 'https://bootstrap.pypa.io/3.5/get-pip.py'
+          GetPip: 'https://bootstrap.pypa.io/pip/3.5/get-pip.py'
         Python 3.6:
           PythonBin: 'python3'
           PythonVersion: '$(PythonVersion36)'
@@ -260,10 +260,10 @@ jobs:
       matrix:
         Python 2.7:
           PythonVersion: '$(PythonVersion27)'
-          GetPip: 'https://bootstrap.pypa.io/2.7/get-pip.py'
+          GetPip: 'https://bootstrap.pypa.io/pip/2.7/get-pip.py'
         Python 3.5:
           PythonVersion: '$(PythonVersion35)'
-          GetPip: 'https://bootstrap.pypa.io/3.5/get-pip.py'
+          GetPip: 'https://bootstrap.pypa.io/pip/3.5/get-pip.py'
         Python 3.6:
           PythonVersion: '$(PythonVersion36)'
         Python 3.7:

--- a/.azure-pipelines/client.yml
+++ b/.azure-pipelines/client.yml
@@ -388,7 +388,7 @@ jobs:
         displayName: 'Build and test with Docker'
         inputs:
           azureContainerRegistry: azuresdkimages.azurecr.io
-          azureSubscriptionEndpoint: 'Azure SDK Images'
+          azureSubscriptionEndpoint: 'Azure SDK ACR'
           command: 'Run an image'
           containerCommand: '/data/build_many_linux.sh'
           envVars: |

--- a/.azure-pipelines/client.yml
+++ b/.azure-pipelines/client.yml
@@ -55,11 +55,11 @@ jobs:
         Python 2.7:
           PythonBin: 'python2'
           PythonVersion: '$(PythonVersion27)'
-          GetPip: 'https://bootstrap.pypa.io/2.7/get-pip.py'
+          GetPip: 'https://bootstrap.pypa.io/pip/2.7/get-pip.py'
         Python 3.5:
           PythonBin: 'python3'
           PythonVersion: '$(PythonVersion35)'
-          GetPip: 'https://bootstrap.pypa.io/3.5/get-pip.py'
+          GetPip: 'https://bootstrap.pypa.io/pip/3.5/get-pip.py'
         Python 3.6:
           PythonBin: 'python3'
           PythonVersion: '$(PythonVersion36)'
@@ -161,11 +161,11 @@ jobs:
         x64 Python 2.7:
           PythonArchitecture: 'x64'
           PythonVersion: '$(PythonVersion27)'
-          GetPip: 'https://bootstrap.pypa.io/2.7/get-pip.py'
+          GetPip: 'https://bootstrap.pypa.io/pip/2.7/get-pip.py'
         x64 Python 3.5:
           PythonArchitecture: 'x64'
           PythonVersion: '$(PythonVersion35)'
-          GetPip: 'https://bootstrap.pypa.io/3.5/get-pip.py'
+          GetPip: 'https://bootstrap.pypa.io/pip/3.5/get-pip.py'
         x64 Python 3.6:
           PythonArchitecture: 'x64'
           PythonVersion: '$(PythonVersion36)'
@@ -181,11 +181,11 @@ jobs:
         x86 Python 2.7:
           PythonArchitecture: 'x86'
           PythonVersion: '$(PythonVersion27)'
-          GetPip: 'https://bootstrap.pypa.io/2.7/get-pip.py'
+          GetPip: 'https://bootstrap.pypa.io/pip/2.7/get-pip.py'
         x86 Python 3.5:
           PythonArchitecture: 'x86'
           PythonVersion: '$(PythonVersion35)'
-          GetPip: 'https://bootstrap.pypa.io/3.5/get-pip.py'
+          GetPip: 'https://bootstrap.pypa.io/pip/3.5/get-pip.py'
         x86 Python 3.6:
           PythonArchitecture: 'x86'
           PythonVersion: '$(PythonVersion36)'
@@ -259,10 +259,10 @@ jobs:
       matrix:
         Python 2.7:
           PythonVersion: '$(PythonVersion27)'
-          GetPip: 'https://bootstrap.pypa.io/2.7/get-pip.py'
+          GetPip: 'https://bootstrap.pypa.io/pip/2.7/get-pip.py'
         Python 3.5:
           PythonVersion: '$(PythonVersion35)'
-          GetPip: 'https://bootstrap.pypa.io/3.5/get-pip.py'
+          GetPip: 'https://bootstrap.pypa.io/pip/3.5/get-pip.py'
         Python 3.6:
           PythonVersion: '$(PythonVersion36)'
         Python 3.7:


### PR DESCRIPTION
CI is reporting:

```
Hi there!

The URL you are using to fetch this script has changed, and this one will no
longer work. Please use get-pip.py from the following URL instead:

    https://bootstrap.pypa.io/pip/3.5/get-pip.py

Sorry if this change causes any inconvenience for you!

We don't have a good mechanism to make more gradual changes here, and this
renaming is a part of an effort to make it easier to us to update these
scripts, when there's a pip release. It's also essential for improving how we
handle the `get-pip.py` scripts, when pip drops support for a Python minor
version.

There are no more renames/URL changes planned, and we don't expect that a need
would arise to do this again in the near future.

Thanks for understanding!

- Pradyun, on behalf of the volunteers who maintain pip.

```

update the get-pip url accordingly