### PR TITLE
add support for sending/receiving message of amqp sequence type

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -7,9 +7,9 @@ Release History
 
 - Added support for AMQP Sequence as the body type of the message.
 - Added new class `uamqp.MessageBodyType` to represent the body type of an amqp message, including:
-  - `DataType`: The body consists of one or more data sections and each section contains opaque binary data.
-  - `SequenceType`: The body consists of one or more sequence sections and each section contains an arbitrary number of structured data elements.
-  - `ValueType`: The body consists of one amqp-value section and the section contains a single AMQP value.
+  - `Data`: The body consists of one or more data sections and each section contains opaque binary data.
+  - `Sequence`: The body consists of one or more sequence sections and each section contains an arbitrary number of structured data elements.
+  - `Value`: The body consists of one amqp-value section and the section contains a single AMQP value.
 - Added new parameter `body_type` to the constructor of `uamqp.Message` which takes `uamqp.MessageBodyType` to specify the body type of an amqp message.
 
 

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -3,6 +3,16 @@
 Release History
 ===============
 
+1.3.0 (Unreleased)
+
+- Added support for AMQP Sequence as the body type of the message.
+- Added new class `uamqp.MessageBodyType` to denote the body type of an amqp message, including:
+  - `DataType`: A data section contains opaque binary data.
+  - `SequenceType`: A sequence section contains an arbitrary number of structured data elements.
+  - `ValueType`: An amqp-value section contains a single AMQP value.
+- Added new parameter `body_type` to the constructor of `uamqp.Message` which takes `uamqp.MessageBodyType` to denote the body type of an amqp message.
+
+
 1.2.15 (2021-03-02)
 +++++++++++++++++++
 

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -5,13 +5,13 @@ Release History
 
 1.3.0 (Unreleased)
 
-- Added support for AMQP Sequence as the body type of the message.
+- Added support for AMQP Sequence as the body type of an amqp message.
 - Added new class `uamqp.MessageBodyType` to represent the body type of an amqp message, including:
   - `Data`: The body consists of one or more data sections and each section contains opaque binary data.
   - `Sequence`: The body consists of one or more sequence sections and each section contains an arbitrary number of structured data elements.
   - `Value`: The body consists of one amqp-value section and the section contains a single AMQP value.
 - Added new parameter `body_type` to the constructor of `uamqp.Message` which takes `uamqp.MessageBodyType` to specify the body type of an amqp message.
-
+- Added new parameter `footer` to the constructor of  `uamqp.Message` which takes a dict to set the footer of an amqp message.
 
 1.2.15 (2021-03-02)
 +++++++++++++++++++

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -6,11 +6,11 @@ Release History
 1.3.0 (Unreleased)
 
 - Added support for AMQP Sequence as the body type of the message.
-- Added new class `uamqp.MessageBodyType` to denote the body type of an amqp message, including:
+- Added new class `uamqp.MessageBodyType` to represent the body type of an amqp message, including:
   - `DataType`: The body consists of one or more data sections and each section contains opaque binary data.
   - `SequenceType`: The body consists of one or more sequence sections and each section contains an arbitrary number of structured data elements.
   - `ValueType`: The body consists of one amqp-value section and the section contains a single AMQP value.
-- Added new parameter `body_type` to the constructor of `uamqp.Message` which takes `uamqp.MessageBodyType` to denote the body type of an amqp message.
+- Added new parameter `body_type` to the constructor of `uamqp.Message` which takes `uamqp.MessageBodyType` to specify the body type of an amqp message.
 
 
 1.2.15 (2021-03-02)

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -7,9 +7,9 @@ Release History
 
 - Added support for AMQP Sequence as the body type of the message.
 - Added new class `uamqp.MessageBodyType` to denote the body type of an amqp message, including:
-  - `DataType`: A data section contains opaque binary data.
-  - `SequenceType`: A sequence section contains an arbitrary number of structured data elements.
-  - `ValueType`: An amqp-value section contains a single AMQP value.
+  - `DataType`: The body consists of one or more data sections and each section contains opaque binary data.
+  - `SequenceType`: The body consists of one or more sequence sections and each section contains an arbitrary number of structured data elements.
+  - `ValueType`: The body consists of one amqp-value section and the section contains a single AMQP value.
 - Added new parameter `body_type` to the constructor of `uamqp.Message` which takes `uamqp.MessageBodyType` to denote the body type of an amqp message.
 
 

--- a/samples/asynctests/test_azure_event_hubs_receive_async.py
+++ b/samples/asynctests/test_azure_event_hubs_receive_async.py
@@ -12,7 +12,8 @@ import sys
 import time
 
 import uamqp
-from uamqp import address, types, utils, authentication
+from uamqp import address, types, utils, authentication, MessageBodyType
+from uamqp.message import DataBody, ValueBody, SequenceBody
 
 
 def get_logger(level):
@@ -497,6 +498,101 @@ async def test_event_hubs_not_receive_events_during_connection_establishment_asy
         await receive_client.close_async()
 
 
+@pytest.mark.asyncio
+async def event_hubs_send_different_amqp_body_type_async(live_eventhub_config):
+
+    uri = "sb://{}/{}".format(live_eventhub_config['hostname'], live_eventhub_config['event_hub'])
+    sas_auth = authentication.SASTokenAsync.from_shared_access_key(
+        uri, live_eventhub_config['key_name'], live_eventhub_config['access_key'])
+
+    target = "amqps://{}/{}/Partitions/0".format(live_eventhub_config['hostname'], live_eventhub_config['event_hub'])
+    send_client = uamqp.SendClientAsync(target, auth=sas_auth, debug=False)
+
+    data_body_1 = [b'data1', b'data2']
+    data_body_message_1 = uamqp.message.Message(body=data_body_1)
+    data_body_message_1.application_properties = {'body_type': 'data_body_1'}
+    send_client.queue_message(data_body_message_1)
+
+    data_body_2 = b'data1'
+    data_body_message_2 = uamqp.message.Message(body=data_body_2, body_type=MessageBodyType.DataType)
+    data_body_message_2.application_properties = {'body_type': 'data_body_2'}
+    send_client.queue_message(data_body_message_2)
+
+    value_body_1 = [b'data1', -1.23, True, {b'key': b'value'}, [1, False, 1.23, b'4']]
+    value_body_message_1 = uamqp.message.Message(body=value_body_1)
+    value_body_message_1.application_properties = {'body_type': 'value_body_1'}
+    send_client.queue_message(value_body_message_1)
+
+    value_body_2 = {b'key1': {b'sub_key': b'sub_value'}, b'key2': b'value', 3: -1.23}
+    value_body_message_2 = uamqp.message.Message(body=value_body_2, body_type=MessageBodyType.ValueType)
+    value_body_message_2.application_properties = {'body_type': 'value_body_2'}
+    send_client.queue_message(value_body_message_2)
+
+    sequence_body_1 = [b'data1', -1.23, True, {b'key': b'value'}, [b'a', 1.23, True]]
+    sequence_body_message_1 = uamqp.message.Message(body=sequence_body_1, body_type=MessageBodyType.SequenceType)
+    sequence_body_message_1.application_properties = {'body_type': 'sequence_body_1'}
+    send_client.queue_message(sequence_body_message_1)
+
+    sequence_body_2 = [[1, 2, 3], [b'aa', b'bb', b'cc'], [True, False, True], [{b'key1': b'value'}, {b'key2': 123}]]
+    sequence_body_message_2 = uamqp.message.Message(body=sequence_body_2, body_type=MessageBodyType.SequenceType)
+    sequence_body_message_2.application_properties = {'body_type': 'sequence_body_2'}
+    send_client.queue_message(sequence_body_message_2)
+
+    results = await send_client.send_all_messages_async(close_on_done=False)
+    assert not [m for m in results if m == uamqp.constants.MessageState.SendFailed]
+
+    sas_auth = authentication.SASTokenAsync.from_shared_access_key(
+        uri, live_eventhub_config['key_name'], live_eventhub_config['access_key'])
+
+    source = "amqps://{}/{}/ConsumerGroups/{}/Partitions/{}".format(
+        live_eventhub_config['hostname'],
+        live_eventhub_config['event_hub'],
+        live_eventhub_config['consumer_group'],
+        0)
+
+    result_dic = {}
+    receive_client = uamqp.ReceiveClientAsync(source, auth=sas_auth, timeout=5000, debug=False, prefetch=10)
+    gen = receive_client.receive_messages_iter_async()
+    async for message in gen:
+        if message.application_properties and message.application_properties.get(b'body_type'):
+            if message.application_properties.get(b'body_type') == b'data_body_1':
+                check_list = [data for data in message.get_data()]
+                assert isinstance(message._body, DataBody)
+                assert check_list == data_body_1
+                result_dic['data_body_1'] = 1
+            elif message.application_properties.get(b'body_type') == b'data_body_2':
+                check_list = [data for data in message.get_data()]
+                assert isinstance(message._body, DataBody)
+                assert check_list == [data_body_2]
+                result_dic['data_body_2'] = 1
+            elif message.application_properties.get(b'body_type') == b'value_body_1':
+                assert message.get_data() == value_body_1
+                assert isinstance(message._body, ValueBody)
+                result_dic['value_body_1'] = 1
+            elif message.application_properties.get(b'body_type') == b'value_body_2':
+                assert message.get_data() == value_body_2
+                assert isinstance(message._body, ValueBody)
+                result_dic['value_body_2'] = 1
+            elif message.application_properties.get(b'body_type') == b'sequence_body_1':
+                check_list = [data for data in message.get_data()]
+                assert check_list == [sequence_body_1]
+                assert isinstance(message._body, SequenceBody)
+                result_dic['sequence_body_1'] = 1
+            elif message.application_properties.get(b'body_type') == b'sequence_body_2':
+                check_list = [data for data in message.get_data()]
+                assert check_list == sequence_body_2
+                assert isinstance(message._body, SequenceBody)
+                result_dic['sequence_body_2'] = 1
+
+            log.info(message.annotations.get(b'x-opt-sequence-number'))
+            log.info(str(message))
+
+
+    await send_client.close_async()
+    await receive_client.close_async()
+    assert len(results) == 6
+
+
 if __name__ == '__main__':
     config = {}
     config['hostname'] = os.environ['EVENT_HUB_HOSTNAME']
@@ -507,4 +603,4 @@ if __name__ == '__main__':
     config['partition'] = "0"
 
     loop = asyncio.get_event_loop()
-    loop.run_until_complete(test_event_hubs_not_receive_events_during_connection_establishment_async(config))
+    loop.run_until_complete(event_hubs_send_different_amqp_body_type_async(config))

--- a/samples/asynctests/test_azure_event_hubs_receive_async.py
+++ b/samples/asynctests/test_azure_event_hubs_receive_async.py
@@ -514,7 +514,7 @@ async def event_hubs_send_different_amqp_body_type_async(live_eventhub_config):
     send_client.queue_message(data_body_message_1)
 
     data_body_2 = b'data1'
-    data_body_message_2 = uamqp.message.Message(body=data_body_2, body_type=MessageBodyType.DataType)
+    data_body_message_2 = uamqp.message.Message(body=data_body_2, body_type=MessageBodyType.Data)
     data_body_message_2.application_properties = {'body_type': 'data_body_2'}
     send_client.queue_message(data_body_message_2)
 
@@ -524,17 +524,17 @@ async def event_hubs_send_different_amqp_body_type_async(live_eventhub_config):
     send_client.queue_message(value_body_message_1)
 
     value_body_2 = {b'key1': {b'sub_key': b'sub_value'}, b'key2': b'value', 3: -1.23}
-    value_body_message_2 = uamqp.message.Message(body=value_body_2, body_type=MessageBodyType.ValueType)
+    value_body_message_2 = uamqp.message.Message(body=value_body_2, body_type=MessageBodyType.Value)
     value_body_message_2.application_properties = {'body_type': 'value_body_2'}
     send_client.queue_message(value_body_message_2)
 
     sequence_body_1 = [b'data1', -1.23, True, {b'key': b'value'}, [b'a', 1.23, True]]
-    sequence_body_message_1 = uamqp.message.Message(body=sequence_body_1, body_type=MessageBodyType.SequenceType)
+    sequence_body_message_1 = uamqp.message.Message(body=sequence_body_1, body_type=MessageBodyType.Sequence)
     sequence_body_message_1.application_properties = {'body_type': 'sequence_body_1'}
     send_client.queue_message(sequence_body_message_1)
 
     sequence_body_2 = [[1, 2, 3], [b'aa', b'bb', b'cc'], [True, False, True], [{b'key1': b'value'}, {b'key2': 123}]]
-    sequence_body_message_2 = uamqp.message.Message(body=sequence_body_2, body_type=MessageBodyType.SequenceType)
+    sequence_body_message_2 = uamqp.message.Message(body=sequence_body_2, body_type=MessageBodyType.Sequence)
     sequence_body_message_2.application_properties = {'body_type': 'sequence_body_2'}
     send_client.queue_message(sequence_body_message_2)
 

--- a/samples/test_azure_event_hubs_receive.py
+++ b/samples/test_azure_event_hubs_receive.py
@@ -638,7 +638,7 @@ def event_hubs_send_different_amqp_body_type_sync(live_eventhub_config):
     send_client.queue_message(data_body_message_1)
 
     data_body_2 = b'data1'
-    data_body_message_2 = uamqp.message.Message(body=data_body_2, body_type=MessageBodyType.DataType)
+    data_body_message_2 = uamqp.message.Message(body=data_body_2, body_type=MessageBodyType.Data)
     data_body_message_2.application_properties = {'body_type': 'data_body_2'}
     send_client.queue_message(data_body_message_2)
 
@@ -648,17 +648,17 @@ def event_hubs_send_different_amqp_body_type_sync(live_eventhub_config):
     send_client.queue_message(value_body_message_1)
 
     value_body_2 = {b'key1': {b'sub_key': b'sub_value'}, b'key2': b'value', 3: -1.23}
-    value_body_message_2 = uamqp.message.Message(body=value_body_2, body_type=MessageBodyType.ValueType)
+    value_body_message_2 = uamqp.message.Message(body=value_body_2, body_type=MessageBodyType.Value)
     value_body_message_2.application_properties = {'body_type': 'value_body_2'}
     send_client.queue_message(value_body_message_2)
 
     sequence_body_1 = [b'data1', -1.23, True, {b'key': b'value'}, [b'a', 1.23, True]]
-    sequence_body_message_1 = uamqp.message.Message(body=sequence_body_1, body_type=MessageBodyType.SequenceType)
+    sequence_body_message_1 = uamqp.message.Message(body=sequence_body_1, body_type=MessageBodyType.Sequence)
     sequence_body_message_1.application_properties = {'body_type': 'sequence_body_1'}
     send_client.queue_message(sequence_body_message_1)
 
     sequence_body_2 = [[1, 2, 3], [b'aa', b'bb', b'cc'], [True, False, True], [{b'key1': b'value'}, {b'key2': 123}]]
-    sequence_body_message_2 = uamqp.message.Message(body=sequence_body_2, body_type=MessageBodyType.SequenceType)
+    sequence_body_message_2 = uamqp.message.Message(body=sequence_body_2, body_type=MessageBodyType.Sequence)
     sequence_body_message_2.application_properties = {'body_type': 'sequence_body_2'}
     send_client.queue_message(sequence_body_message_2)
 

--- a/samples/test_azure_event_hubs_receive.py
+++ b/samples/test_azure_event_hubs_receive.py
@@ -16,7 +16,8 @@ except Exception:
     from urllib.parse import quote_plus
 
 import uamqp
-from uamqp import address, types, utils, authentication
+from uamqp import address, types, utils, authentication, MessageBodyType
+from uamqp.message import DataBody, SequenceBody, ValueBody
 
 
 def get_logger(level):
@@ -622,6 +623,99 @@ def test_event_hubs_not_receive_events_during_connection_establishment(live_even
         receive_client.close()
 
 
+def event_hubs_send_different_amqp_body_type_sync(live_eventhub_config):
+
+    uri = "sb://{}/{}".format(live_eventhub_config['hostname'], live_eventhub_config['event_hub'])
+    sas_auth = authentication.SASTokenAuth.from_shared_access_key(
+        uri, live_eventhub_config['key_name'], live_eventhub_config['access_key'])
+
+    target = "amqps://{}/{}/Partitions/0".format(live_eventhub_config['hostname'], live_eventhub_config['event_hub'])
+    send_client = uamqp.SendClient(target, auth=sas_auth, debug=False)
+
+    data_body_1 = [b'data1', b'data2']
+    data_body_message_1 = uamqp.message.Message(body=data_body_1)
+    data_body_message_1.application_properties = {'body_type': 'data_body_1'}
+    send_client.queue_message(data_body_message_1)
+
+    data_body_2 = b'data1'
+    data_body_message_2 = uamqp.message.Message(body=data_body_2, body_type=MessageBodyType.DataType)
+    data_body_message_2.application_properties = {'body_type': 'data_body_2'}
+    send_client.queue_message(data_body_message_2)
+
+    value_body_1 = [b'data1', -1.23, True, {b'key': b'value'}, [1, False, 1.23, b'4']]
+    value_body_message_1 = uamqp.message.Message(body=value_body_1)
+    value_body_message_1.application_properties = {'body_type': 'value_body_1'}
+    send_client.queue_message(value_body_message_1)
+
+    value_body_2 = {b'key1': {b'sub_key': b'sub_value'}, b'key2': b'value', 3: -1.23}
+    value_body_message_2 = uamqp.message.Message(body=value_body_2, body_type=MessageBodyType.ValueType)
+    value_body_message_2.application_properties = {'body_type': 'value_body_2'}
+    send_client.queue_message(value_body_message_2)
+
+    sequence_body_1 = [b'data1', -1.23, True, {b'key': b'value'}, [b'a', 1.23, True]]
+    sequence_body_message_1 = uamqp.message.Message(body=sequence_body_1, body_type=MessageBodyType.SequenceType)
+    sequence_body_message_1.application_properties = {'body_type': 'sequence_body_1'}
+    send_client.queue_message(sequence_body_message_1)
+
+    sequence_body_2 = [[1, 2, 3], [b'aa', b'bb', b'cc'], [True, False, True], [{b'key1': b'value'}, {b'key2': 123}]]
+    sequence_body_message_2 = uamqp.message.Message(body=sequence_body_2, body_type=MessageBodyType.SequenceType)
+    sequence_body_message_2.application_properties = {'body_type': 'sequence_body_2'}
+    send_client.queue_message(sequence_body_message_2)
+
+    results = send_client.send_all_messages(close_on_done=False)
+    assert not [m for m in results if m == uamqp.constants.MessageState.SendFailed]
+
+    sas_auth = authentication.SASTokenAuth.from_shared_access_key(
+        uri, live_eventhub_config['key_name'], live_eventhub_config['access_key'])
+
+    source = "amqps://{}/{}/ConsumerGroups/{}/Partitions/{}".format(
+        live_eventhub_config['hostname'],
+        live_eventhub_config['event_hub'],
+        live_eventhub_config['consumer_group'],
+        0)
+
+    result_dic = {}
+    receive_client = uamqp.ReceiveClient(source, auth=sas_auth, timeout=5000, debug=False, prefetch=10)
+    gen = receive_client.receive_messages_iter()
+    for message in gen:
+        if message.application_properties and message.application_properties.get(b'body_type'):
+            if message.application_properties.get(b'body_type') == b'data_body_1':
+                check_list = [data for data in message.get_data()]
+                assert isinstance(message._body, DataBody)
+                assert check_list == data_body_1
+                result_dic['data_body_1'] = 1
+            elif message.application_properties.get(b'body_type') == b'data_body_2':
+                check_list = [data for data in message.get_data()]
+                assert isinstance(message._body, DataBody)
+                assert check_list == [data_body_2]
+                result_dic['data_body_2'] = 1
+            elif message.application_properties.get(b'body_type') == b'value_body_1':
+                assert message.get_data() == value_body_1
+                assert isinstance(message._body, ValueBody)
+                result_dic['value_body_1'] = 1
+            elif message.application_properties.get(b'body_type') == b'value_body_2':
+                assert message.get_data() == value_body_2
+                assert isinstance(message._body, ValueBody)
+                result_dic['value_body_2'] = 1
+            elif message.application_properties.get(b'body_type') == b'sequence_body_1':
+                check_list = [data for data in message.get_data()]
+                assert check_list == [sequence_body_1]
+                assert isinstance(message._body, SequenceBody)
+                result_dic['sequence_body_1'] = 1
+            elif message.application_properties.get(b'body_type') == b'sequence_body_2':
+                check_list = [data for data in message.get_data()]
+                assert check_list == sequence_body_2
+                assert isinstance(message._body, SequenceBody)
+                result_dic['sequence_body_2'] = 1
+
+            log.info(message.annotations.get(b'x-opt-sequence-number'))
+            log.info(str(message))
+
+    send_client.close()
+    receive_client.close()
+    assert len(result_dic) == 6
+
+
 if __name__ == '__main__':
     config = {}
     config['hostname'] = os.environ['EVENT_HUB_HOSTNAME']
@@ -630,4 +724,4 @@ if __name__ == '__main__':
     config['access_key'] = os.environ['EVENT_HUB_SAS_KEY']
     config['consumer_group'] = "$Default"
     config['partition'] = "0"
-    test_event_hubs_not_receive_events_during_connection_establishment(config)
+    event_hubs_send_different_amqp_body_type_sync(config)

--- a/src/message.pyx
+++ b/src/message.pyx
@@ -286,10 +286,13 @@ cdef class cMessage(StructBase):
 
     cpdef get_body_sequence(self, size_t index):
         cdef c_amqpvalue.AMQP_VALUE _value
-        if c_message.message_get_body_amqp_sequence_in_place(self._c_value, index, &_value) == 0:
-            return value_factory(_value)
-        else:
+        cdef c_amqpvalue.AMQP_VALUE cloned
+        if c_message.message_get_body_amqp_sequence_in_place(self._c_value, index, &_value) != 0:
             self._value_error()
+        cloned = c_amqpvalue.amqpvalue_clone(_value)
+        if <void*>cloned == NULL:
+            self._value_error()
+        return value_factory(cloned)
 
     cpdef count_body_sequence(self):
         cdef size_t body_count

--- a/src/vendor/azure-uamqp-c/inc/azure_uamqp_c/amqpvalue.h
+++ b/src/vendor/azure-uamqp-c/inc/azure_uamqp_c/amqpvalue.h
@@ -69,6 +69,7 @@ extern "C" {
     MOCKABLE_FUNCTION(, int, amqpvalue_get_list_item_count, AMQP_VALUE, list, uint32_t*, count);
     MOCKABLE_FUNCTION(, int, amqpvalue_set_list_item, AMQP_VALUE, list, uint32_t, index, AMQP_VALUE, list_item_value);
     MOCKABLE_FUNCTION(, AMQP_VALUE, amqpvalue_get_list_item, AMQP_VALUE, list, size_t, index);
+    MOCKABLE_FUNCTION(, int, amqpvalue_get_list, AMQP_VALUE, from_value, AMQP_VALUE*, list);
     MOCKABLE_FUNCTION(, AMQP_VALUE, amqpvalue_create_map);
     MOCKABLE_FUNCTION(, int, amqpvalue_set_map_value, AMQP_VALUE, map, AMQP_VALUE, key, AMQP_VALUE, value);
     MOCKABLE_FUNCTION(, AMQP_VALUE, amqpvalue_get_map_value, AMQP_VALUE, map, AMQP_VALUE, key);

--- a/src/vendor/azure-uamqp-c/src/amqpvalue.c
+++ b/src/vendor/azure-uamqp-c/src/amqpvalue.c
@@ -1502,6 +1502,35 @@ AMQP_VALUE amqpvalue_get_list_item(AMQP_VALUE value, size_t index)
     return result;
 }
 
+int amqpvalue_get_list(AMQP_VALUE value, AMQP_VALUE* list_value)
+{
+    int result;
+
+    if ((value == NULL) ||
+        (list_value == NULL))
+    {
+        LogError("Bad arguments: value = %p, list_value = %p",
+            value, list_value);
+        result = MU_FAILURE;
+    }
+    else
+    {
+        AMQP_VALUE_DATA* value_data = (AMQP_VALUE_DATA*)value;
+        if (value_data->type != AMQP_TYPE_LIST)
+        {
+            LogError("Value is not of type LIST");
+            result = MU_FAILURE;
+        }
+        else
+        {
+            *list_value = value;
+            result = 0;
+        }
+    }
+
+    return result;
+}
+
 /* Codes_SRS_AMQPVALUE_01_178: [amqpvalue_create_map shall create an AMQP value that holds a map and return a handle to it.] */
 /* Codes_SRS_AMQPVALUE_01_031: [1.6.23 map A polymorphic mapping from distinct keys to values.] */
 AMQP_VALUE amqpvalue_create_map(void)

--- a/src/vendor/azure-uamqp-c/src/message_receiver.c
+++ b/src/vendor/azure-uamqp-c/src/message_receiver.c
@@ -218,6 +218,50 @@ static void decode_message_value_callback(void* context, AMQP_VALUE decoded_valu
             }
         }
     }
+    else if (is_amqp_sequence_type_by_descriptor(descriptor))
+    {
+        MESSAGE_BODY_TYPE body_type;
+        if (message_get_body_type(decoded_message, &body_type) != 0)
+        {
+            LogError("Error getting message body type");
+            message_receiver->decode_error = true;
+        }
+        else
+        {
+            if ((body_type != MESSAGE_BODY_TYPE_NONE) &&
+                (body_type != MESSAGE_BODY_TYPE_SEQUENCE))
+            {
+                LogError("Message body type already set to something different than AMQP SEQUENCE");
+                message_receiver->decode_error = true;
+            }
+            else
+            {
+                AMQP_VALUE body_amqp_sequence = amqpvalue_get_inplace_described_value(decoded_value);
+                if (body_amqp_sequence == NULL)
+                {
+                    LogError("Error getting body AMQP sequence");
+                    message_receiver->decode_error = true;
+                }
+                else
+                {
+                    AMQP_VALUE sequence_value;
+                    if (amqpvalue_get_amqp_sequence(body_amqp_sequence, &sequence_value) != 0)
+                    {
+                        LogError("Error getting body SEQUENCE AMQP value");
+                        message_receiver->decode_error = true;
+                    }
+                    else
+                    {
+                        if (message_add_body_amqp_sequence(decoded_message, sequence_value) != 0)
+                        {
+                            LogError("Error setting body AMQP sequence on received message");
+                            message_receiver->decode_error = true;
+                        }
+                    }
+                }
+            }
+        }
+    }
 }
 
 static AMQP_VALUE on_transfer_received(void* context, TRANSFER_HANDLE transfer, uint32_t payload_size, const unsigned char* payload_bytes)

--- a/tests/test_message.py
+++ b/tests/test_message.py
@@ -1,7 +1,10 @@
-from uamqp.message import MessageProperties
+import pytest
+
+from uamqp.message import MessageProperties, Message, SequenceBody, DataBody, ValueBody
+from uamqp import MessageBodyType
 
 
-def test_message_proeprties():
+def test_message_properties():
 
     properties = MessageProperties()
     assert properties.user_id is None
@@ -29,3 +32,132 @@ def test_message_proeprties():
     properties = MessageProperties()
     properties.user_id = 'werid/0\0\1\t\n'
     assert properties.user_id == b'werid/0\0\1\t\n'
+
+
+def test_message_auto_body_type():
+    single_data = b'!@#$%^&*()_+1234567890'
+    single_data_message = Message(body=single_data)
+    check_list = [data for data in single_data_message.get_data()]
+    assert isinstance(single_data_message._body, DataBody)
+    assert len(check_list) == 1
+    assert check_list[0] == single_data
+    assert(str(single_data_message))
+
+    multiple_data = [b'!@#$%^&*()_+1234567890', 'abcdefg~123']
+    multiple_data_message = Message(body=multiple_data)
+    check_list = [data for data in multiple_data_message.get_data()]
+    assert isinstance(multiple_data_message._body, DataBody)
+    assert len(check_list) == 2
+    assert check_list[0] == multiple_data[0]
+    assert check_list[1] == multiple_data[1].encode("UTF-8")
+    assert (str(multiple_data_message))
+
+    list_mixed_body = [b'!@#$%^&*()_+1234567890', 'abcdefg~123', False, 1.23]
+    list_mixed_body_message = Message(body=list_mixed_body)
+    check_data = list_mixed_body_message.get_data()
+    assert isinstance(list_mixed_body_message._body, ValueBody)
+    assert isinstance(check_data, list)
+    assert len(check_data) == 4
+    assert check_data[0] == list_mixed_body[0]
+    assert check_data[1] == list_mixed_body[1].encode("UTF-8")
+    assert check_data[2] == list_mixed_body[2]
+    assert check_data[3] == list_mixed_body[3]
+    assert (str(list_mixed_body_message))
+
+    dic_mixed_body = {b'key1': b'value', b'key2': False, b'key3': -1.23}
+    dic_mixed_body_message = Message(body=dic_mixed_body)
+    check_data = dic_mixed_body_message.get_data()
+    assert isinstance(dic_mixed_body_message._body, ValueBody)
+    assert isinstance(check_data, dict)
+    assert len(check_data) == 3
+    assert check_data == dic_mixed_body
+    assert (str(dic_mixed_body_message))
+
+
+def test_message_body_data_type():
+    single_data = b'!@#$%^&*()_+1234567890'
+    single_data_message = Message(body=single_data, body_type=MessageBodyType.DataType)
+    check_list = [data for data in single_data_message.get_data()]
+    assert isinstance(single_data_message._body, DataBody)
+    assert len(check_list) == 1
+    assert check_list[0] == single_data
+    assert str(single_data_message)
+
+    multiple_data = [b'!@#$%^&*()_+1234567890', 'abcdefg~123',]
+    multiple_data_message = Message(body=multiple_data, body_type=MessageBodyType.DataType)
+    check_list = [data for data in multiple_data_message.get_data()]
+    assert isinstance(multiple_data_message._body, DataBody)
+    assert len(check_list) == 2
+    assert check_list[0] == multiple_data[0]
+    assert check_list[1] == multiple_data[1].encode("UTF-8")
+    assert str(multiple_data_message)
+
+    with pytest.raises(TypeError):
+        Message(body={"key": "value"}, body_type=MessageBodyType.DataType)
+
+    with pytest.raises(TypeError):
+        Message(body=1, body_type=MessageBodyType.DataType)
+
+    with pytest.raises(TypeError):
+        Message(body=['abc', True], body_type=MessageBodyType.DataType)
+
+    with pytest.raises(TypeError):
+        Message(body=True, body_type=MessageBodyType.DataType)
+
+
+def test_message_body_value_type():
+    string_value = b'!@#$%^&*()_+1234567890'
+    string_value_message = Message(body=string_value, body_type=MessageBodyType.ValueType)
+    assert string_value_message.get_data() == string_value
+    assert isinstance(string_value_message._body, ValueBody)
+    assert str(string_value_message)
+
+    float_value = 1.23
+    float_value_message = Message(body=float_value, body_type=MessageBodyType.ValueType)
+    assert float_value_message.get_data() == float_value
+    assert isinstance(string_value_message._body, ValueBody)
+    assert str(float_value_message)
+
+    dict_value = {b"key1 ": b"value1", b'key2': -1, b'key3': False}
+    dict_value_message = Message(body=dict_value, body_type=MessageBodyType.ValueType)
+    assert dict_value_message.get_data() == dict_value
+    assert isinstance(string_value_message._body, ValueBody)
+    assert str(dict_value_message)
+
+    compound_list_value = [1, b'abc', True, [1.23, b'abc', False], {b"key1 ": b"value1", b'key2': -1}]
+    compound_list_value_message = Message(body=compound_list_value, body_type=MessageBodyType.ValueType)
+    assert compound_list_value_message.get_data() == compound_list_value
+    assert isinstance(string_value_message._body, ValueBody)
+    assert str(compound_list_value_message)
+
+
+def test_message_body_sequence_type():
+
+    single_list = [1, 2, b'aa', b'bb', True, b"abc", {b"key1": b"value", b"key2": -1.23}]
+    single_list_message = Message(body=single_list, body_type=MessageBodyType.SequenceType)
+    check_list = [data for data in single_list_message.get_data()]
+    assert isinstance(single_list_message._body, SequenceBody)
+    assert len(check_list) == 1
+    assert check_list[0] == single_list
+    assert str(single_list_message)
+
+    multiple_lists = [[1, 2, 3, 4], [b'aa', b'bb', b'cc', b'dd']]
+    multiple_lists_message = Message(body=multiple_lists, body_type=MessageBodyType.SequenceType)
+    check_list = [data for data in multiple_lists_message.get_data()]
+    assert isinstance(multiple_lists_message._body, SequenceBody)
+    assert len(check_list) == 2
+    assert check_list[0] == multiple_lists[0]
+    assert check_list[1] == multiple_lists[1]
+    assert str(multiple_lists_message)
+
+    with pytest.raises(TypeError):
+        Message(body={"key": "value"}, body_type=MessageBodyType.SequenceType)
+
+    with pytest.raises(TypeError):
+        Message(body=1, body_type=MessageBodyType.SequenceType)
+
+    with pytest.raises(TypeError):
+        Message(body='a', body_type=MessageBodyType.SequenceType)
+
+    with pytest.raises(TypeError):
+        Message(body=True, body_type=MessageBodyType.SequenceType)

--- a/tests/test_message.py
+++ b/tests/test_message.py
@@ -76,7 +76,7 @@ def test_message_auto_body_type():
 
 def test_message_body_data_type():
     single_data = b'!@#$%^&*()_+1234567890'
-    single_data_message = Message(body=single_data, body_type=MessageBodyType.DataType)
+    single_data_message = Message(body=single_data, body_type=MessageBodyType.Data)
     check_list = [data for data in single_data_message.get_data()]
     assert isinstance(single_data_message._body, DataBody)
     assert len(check_list) == 1
@@ -84,7 +84,7 @@ def test_message_body_data_type():
     assert str(single_data_message)
 
     multiple_data = [b'!@#$%^&*()_+1234567890', 'abcdefg~123',]
-    multiple_data_message = Message(body=multiple_data, body_type=MessageBodyType.DataType)
+    multiple_data_message = Message(body=multiple_data, body_type=MessageBodyType.Data)
     check_list = [data for data in multiple_data_message.get_data()]
     assert isinstance(multiple_data_message._body, DataBody)
     assert len(check_list) == 2
@@ -93,39 +93,39 @@ def test_message_body_data_type():
     assert str(multiple_data_message)
 
     with pytest.raises(TypeError):
-        Message(body={"key": "value"}, body_type=MessageBodyType.DataType)
+        Message(body={"key": "value"}, body_type=MessageBodyType.Data)
 
     with pytest.raises(TypeError):
-        Message(body=1, body_type=MessageBodyType.DataType)
+        Message(body=1, body_type=MessageBodyType.Data)
 
     with pytest.raises(TypeError):
-        Message(body=['abc', True], body_type=MessageBodyType.DataType)
+        Message(body=['abc', True], body_type=MessageBodyType.Data)
 
     with pytest.raises(TypeError):
-        Message(body=True, body_type=MessageBodyType.DataType)
+        Message(body=True, body_type=MessageBodyType.Data)
 
 
 def test_message_body_value_type():
     string_value = b'!@#$%^&*()_+1234567890'
-    string_value_message = Message(body=string_value, body_type=MessageBodyType.ValueType)
+    string_value_message = Message(body=string_value, body_type=MessageBodyType.Value)
     assert string_value_message.get_data() == string_value
     assert isinstance(string_value_message._body, ValueBody)
     assert str(string_value_message)
 
     float_value = 1.23
-    float_value_message = Message(body=float_value, body_type=MessageBodyType.ValueType)
+    float_value_message = Message(body=float_value, body_type=MessageBodyType.Value)
     assert float_value_message.get_data() == float_value
     assert isinstance(string_value_message._body, ValueBody)
     assert str(float_value_message)
 
     dict_value = {b"key1 ": b"value1", b'key2': -1, b'key3': False}
-    dict_value_message = Message(body=dict_value, body_type=MessageBodyType.ValueType)
+    dict_value_message = Message(body=dict_value, body_type=MessageBodyType.Value)
     assert dict_value_message.get_data() == dict_value
     assert isinstance(string_value_message._body, ValueBody)
     assert str(dict_value_message)
 
     compound_list_value = [1, b'abc', True, [1.23, b'abc', False], {b"key1 ": b"value1", b'key2': -1}]
-    compound_list_value_message = Message(body=compound_list_value, body_type=MessageBodyType.ValueType)
+    compound_list_value_message = Message(body=compound_list_value, body_type=MessageBodyType.Value)
     assert compound_list_value_message.get_data() == compound_list_value
     assert isinstance(string_value_message._body, ValueBody)
     assert str(compound_list_value_message)
@@ -134,7 +134,7 @@ def test_message_body_value_type():
 def test_message_body_sequence_type():
 
     single_list = [1, 2, b'aa', b'bb', True, b"abc", {b"key1": b"value", b"key2": -1.23}]
-    single_list_message = Message(body=single_list, body_type=MessageBodyType.SequenceType)
+    single_list_message = Message(body=single_list, body_type=MessageBodyType.Sequence)
     check_list = [data for data in single_list_message.get_data()]
     assert isinstance(single_list_message._body, SequenceBody)
     assert len(check_list) == 1
@@ -142,7 +142,7 @@ def test_message_body_sequence_type():
     assert str(single_list_message)
 
     multiple_lists = [[1, 2, 3, 4], [b'aa', b'bb', b'cc', b'dd']]
-    multiple_lists_message = Message(body=multiple_lists, body_type=MessageBodyType.SequenceType)
+    multiple_lists_message = Message(body=multiple_lists, body_type=MessageBodyType.Sequence)
     check_list = [data for data in multiple_lists_message.get_data()]
     assert isinstance(multiple_lists_message._body, SequenceBody)
     assert len(check_list) == 2
@@ -151,13 +151,13 @@ def test_message_body_sequence_type():
     assert str(multiple_lists_message)
 
     with pytest.raises(TypeError):
-        Message(body={"key": "value"}, body_type=MessageBodyType.SequenceType)
+        Message(body={"key": "value"}, body_type=MessageBodyType.Sequence)
 
     with pytest.raises(TypeError):
-        Message(body=1, body_type=MessageBodyType.SequenceType)
+        Message(body=1, body_type=MessageBodyType.Sequence)
 
     with pytest.raises(TypeError):
-        Message(body='a', body_type=MessageBodyType.SequenceType)
+        Message(body='a', body_type=MessageBodyType.Sequence)
 
     with pytest.raises(TypeError):
-        Message(body=True, body_type=MessageBodyType.SequenceType)
+        Message(body=True, body_type=MessageBodyType.Sequence)

--- a/uamqp/__init__.py
+++ b/uamqp/__init__.py
@@ -19,7 +19,7 @@ from uamqp.session import Session
 from uamqp.client import AMQPClient, SendClient, ReceiveClient
 from uamqp.sender import MessageSender
 from uamqp.receiver import MessageReceiver
-from uamqp.constants import TransportType
+from uamqp.constants import TransportType, MessageBodyType
 
 try:
     from uamqp.async_ops import ConnectionAsync
@@ -35,7 +35,7 @@ except (SyntaxError, ImportError):
     pass  # Async not supported.
 
 
-__version__ = "1.2.15"
+__version__ = "1.3.0"
 
 
 _logger = logging.getLogger(__name__)

--- a/uamqp/constants.py
+++ b/uamqp/constants.py
@@ -170,3 +170,20 @@ class TransportType(Enum):
     """
     Amqp = 1
     AmqpOverWebsocket = 2
+
+
+class MessageBodyType(Enum):
+    """AMQP message body type
+    The body of an amqp message consists of either: one or more data sections, one or more amqp-sequence sections,
+    or a single amqp-value section:
+     AMQP Data: A data section contains opaque binary data.
+     AMQP Sequence: A sequence section contains an arbitrary number of structured data elements.
+     AMQP Value: An amqp-value section contains a single AMQP value.
+
+    Please refer to the AMQP spec:
+    http://docs.oasis-open.org/amqp/core/v1.0/os/amqp-core-messaging-v1.0-os.html#section-message-format
+    for further information on the message body type.
+    """
+    DataType = c_uamqp.MessageBodyType.DataType
+    ValueType = c_uamqp.MessageBodyType.ValueType
+    SequenceType = c_uamqp.MessageBodyType.SequenceType

--- a/uamqp/constants.py
+++ b/uamqp/constants.py
@@ -185,6 +185,6 @@ class MessageBodyType(Enum):
     http://docs.oasis-open.org/amqp/core/v1.0/os/amqp-core-messaging-v1.0-os.html#section-message-format
     for further information on the message body type.
     """
-    DataType = c_uamqp.MessageBodyType.DataType
-    ValueType = c_uamqp.MessageBodyType.ValueType
-    SequenceType = c_uamqp.MessageBodyType.SequenceType
+    Data = c_uamqp.MessageBodyType.DataType
+    Value = c_uamqp.MessageBodyType.ValueType
+    Sequence = c_uamqp.MessageBodyType.SequenceType

--- a/uamqp/constants.py
+++ b/uamqp/constants.py
@@ -176,9 +176,10 @@ class MessageBodyType(Enum):
     """AMQP message body type
     The body of an amqp message consists of either: one or more data sections, one or more amqp-sequence sections,
     or a single amqp-value section:
-     AMQP Data: A data section contains opaque binary data.
-     AMQP Sequence: A sequence section contains an arbitrary number of structured data elements.
-     AMQP Value: An amqp-value section contains a single AMQP value.
+    `DataType`: The body consists of one or more data sections and each section contains opaque binary data.
+    `SequenceType`: The body consists of one or more sequence sections and each section contains an arbitrary
+     number of structured data elements.
+    `ValueType`: The body consists of one amqp-value section and the section contains a single AMQP value.
 
     Please refer to the AMQP spec:
     http://docs.oasis-open.org/amqp/core/v1.0/os/amqp-core-messaging-v1.0-os.html#section-message-format

--- a/uamqp/message.py
+++ b/uamqp/message.py
@@ -82,8 +82,8 @@ class Message(object):
                  message=None,
                  settler=None,
                  delivery_no=None,
-                 body_type=None,
-                 encoding='UTF-8'):
+                 encoding='UTF-8',
+                 body_type=None):
         self.state = constants.MessageState.WaitingToBeSent
         self.idle_time = 0
         self.retries = 0

--- a/uamqp/message.py
+++ b/uamqp/message.py
@@ -282,8 +282,7 @@ class Message(object):
         if isinstance(body, (six.text_type, six.binary_type)) or \
                 (isinstance(body, list) and all([isinstance(b, (six.text_type, six.binary_type)) for b in body])):
             return constants.MessageBodyType.DataType
-        else:
-            return constants.MessageBodyType.ValueType
+        return constants.MessageBodyType.ValueType
 
     @staticmethod
     def _validate_body_and_body_type(body, body_type):
@@ -1146,7 +1145,7 @@ class SequenceBody(MessageBody):
                 if isinstance(d, six.binary_type):
                     output_unicode += d.decode(self._encoding)
                 else:
-                    output_unicode += unicode(self.d)
+                    output_unicode += unicode(self.d)  # pylint: disable=undefined-variable
         return output_unicode
 
     def __bytes__(self):

--- a/uamqp/message.py
+++ b/uamqp/message.py
@@ -1145,7 +1145,7 @@ class SequenceBody(MessageBody):
                 if isinstance(d, six.binary_type):
                     output_unicode += d.decode(self._encoding)
                 else:
-                    output_unicode += unicode(self.d)  # pylint: disable=undefined-variable
+                    output_unicode += unicode(d)  # pylint: disable=undefined-variable
         return output_unicode
 
     def __bytes__(self):

--- a/uamqp/message.py
+++ b/uamqp/message.py
@@ -48,7 +48,7 @@ class Message(object):
     :type header: ~uamqp.message.MessageHeader
     :param msg_format: A custom message format. Default is 0.
     :type msg_format: int
-    :param body_type: The AMQP body type used to construct the body section of an amqp message.
+    :param body_type: The AMQP body type used to specify the type of the body section of an amqp message.
      By default is None which means depending on the nature of the data,
      different body encoding will be used. If the data is str or bytes,
      a single part DataBody will be sent. If the data is a list of str/bytes,

--- a/uamqp/message.py
+++ b/uamqp/message.py
@@ -48,14 +48,6 @@ class Message(object):
     :type header: ~uamqp.message.MessageHeader
     :param msg_format: A custom message format. Default is 0.
     :type msg_format: int
-    :param body_type: The AMQP body type used to specify the type of the body section of an amqp message.
-     By default is None which means depending on the nature of the data,
-     different body encoding will be used. If the data is str or bytes,
-     a single part DataBody will be sent. If the data is a list of str/bytes,
-     a multipart DataBody will be sent. Any other type of list or any other
-     type of data will be sent as a ValueBody. An empty payload will also be sent as a ValueBody.
-     Please check class ~uamqp.MessageBodyType for usage information of each body type.
-    :type body_type: ~uamqp.MessageBodyType
     :param message: Internal only. This is used to wrap an existing message
      that has been received from an AMQP service. If specified, all other
      parameters will be ignored.
@@ -70,6 +62,16 @@ class Message(object):
     :param encoding: The encoding to use for parameters supplied as strings.
      Default is 'UTF-8'
     :type encoding: str
+    :param body_type: The AMQP body type used to specify the type of the body section of an amqp message.
+     By default is None which means depending on the nature of the data,
+     different body encoding will be used. If the data is str or bytes,
+     a single part DataBody will be sent. If the data is a list of str/bytes,
+     a multipart DataBody will be sent. Any other type of list or any other
+     type of data will be sent as a ValueBody. An empty payload will also be sent as a ValueBody.
+     Please check class ~uamqp.MessageBodyType for usage information of each body type.
+    :type body_type: ~uamqp.MessageBodyType
+    :param footer: The message footer.
+    :type footer: dict
     """
 
     def __init__(self,
@@ -83,7 +85,8 @@ class Message(object):
                  settler=None,
                  delivery_no=None,
                  encoding='UTF-8',
-                 body_type=None):
+                 body_type=None,
+                 footer=None):
         self.state = constants.MessageState.WaitingToBeSent
         self.idle_time = 0
         self.retries = 0
@@ -124,6 +127,7 @@ class Message(object):
             self._application_properties = application_properties
             self._annotations = annotations
             self._header = header
+            self._footer = footer
 
     @property
     def properties(self):

--- a/uamqp/message.py
+++ b/uamqp/message.py
@@ -17,12 +17,16 @@ _logger = logging.getLogger(__name__)
 class Message(object):
     """An AMQP message.
 
-    When sending, depending on the nature of the data,
+    When sending, if body type information is not provided,
+    then depending on the nature of the data,
     different body encoding will be used. If the data is str or bytes,
     a single part DataBody will be sent. If the data is a list of str/bytes,
     a multipart DataBody will be sent. Any other type of list or any other
     type of data will be sent as a ValueBody.
     An empty payload will also be sent as a ValueBody.
+    If body type information is provided, then the Message will use the given
+    body type to encode the data or raise error if the data doesn't match the body type.
+
 
     :ivar on_send_complete: A custom callback to be run on completion of
      the send operation of this message. The callback must take two parameters,
@@ -44,6 +48,14 @@ class Message(object):
     :type header: ~uamqp.message.MessageHeader
     :param msg_format: A custom message format. Default is 0.
     :type msg_format: int
+    :param body_type: The AMQP body type used to construct the body section of an amqp message.
+     By default is None which means depending on the nature of the data,
+     different body encoding will be used. If the data is str or bytes,
+     a single part DataBody will be sent. If the data is a list of str/bytes,
+     a multipart DataBody will be sent. Any other type of list or any other
+     type of data will be sent as a ValueBody. An empty payload will also be sent as a ValueBody.
+     Please check class ~uamqp.MessageBodyType for usage information of each body type.
+    :type body_type: ~uamqp.MessageBodyType
     :param message: Internal only. This is used to wrap an existing message
      that has been received from an AMQP service. If specified, all other
      parameters will be ignored.
@@ -70,6 +82,7 @@ class Message(object):
                  message=None,
                  settler=None,
                  delivery_no=None,
+                 body_type=None,
                  encoding='UTF-8'):
         self.state = constants.MessageState.WaitingToBeSent
         self.idle_time = 0
@@ -99,16 +112,11 @@ class Message(object):
             self._parse_message_body(message)
         else:
             self._message = c_uamqp.create_message()
-            if isinstance(body, (six.text_type, six.binary_type)):
-                self._body = DataBody(self._message)
-                self._body.append(body)
-            elif isinstance(body, list) and all([isinstance(b, (six.text_type, six.binary_type)) for b in body]):
-                self._body = DataBody(self._message)
-                for value in body:
-                    self._body.append(value)
-            else:
-                self._body = ValueBody(self._message)
-                self._body.set(body)
+            # if body_type is not given, we detect the body type by checking the type of the object
+            body_type = body_type or self._get_body_type(body)
+            self._validate_body_and_body_type(body, body_type)
+            self._set_body_by_body_type(body, body_type)
+
             if msg_format:
                 self._message.message_format = msg_format
             self._properties = properties
@@ -252,7 +260,7 @@ class Message(object):
         elif body_type == c_uamqp.MessageBodyType.DataType:
             self._body = DataBody(self._message)
         elif body_type == c_uamqp.MessageBodyType.SequenceType:
-            raise TypeError("Message body type Sequence not supported.")
+            self._body = SequenceBody(self._message)
         else:
             self._body = ValueBody(self._message)
         self._need_further_parse = True
@@ -263,6 +271,58 @@ class Message(object):
         if self.settled:
             return False
         return True
+
+    @staticmethod
+    def _get_body_type(body):
+        """
+        Automatically detect the MessageBodyType when no body type information is provided.
+        We categorize object of type list/list of lists into ValueType (not into SequenceType) due to
+        compatibility with old uamqp version.
+        """
+        if isinstance(body, (six.text_type, six.binary_type)) or \
+                (isinstance(body, list) and all([isinstance(b, (six.text_type, six.binary_type)) for b in body])):
+            return constants.MessageBodyType.DataType
+        else:
+            return constants.MessageBodyType.ValueType
+
+    @staticmethod
+    def _validate_body_and_body_type(body, body_type):
+        if body_type == constants.MessageBodyType.DataType:
+            if not (isinstance(body, (six.text_type, six.binary_type)) or
+                    (isinstance(body, list) and all([isinstance(b, (six.text_type, six.binary_type)) for b in body]))):
+                raise TypeError(
+                    "For MessageBodyType.DataType, the body"
+                    " must be str or bytes or list of str or bytes.")
+        elif body_type == constants.MessageBodyType.SequenceType:
+            if not (isinstance(body, list) or
+                    (isinstance(body, list) and all([isinstance(b, list) for b in body]))):
+                raise TypeError(
+                    "For MessageBodyType.SequenceType, the body"
+                    " must be list or list of lists.")
+        elif body_type == constants.MessageBodyType.ValueType:
+            # For MessageBodyType.ValueType, the body could by any type.
+            pass
+        else:
+            raise ValueError("Unsupported MessageBodyType: {}".format(body_type))
+
+    def _set_body_by_body_type(self, body, body_type):
+        if body_type == constants.MessageBodyType.DataType:
+            self._body = DataBody(self._message)
+            if isinstance(body, (six.text_type, six.binary_type)):
+                self._body.append(body)
+            elif isinstance(body, list) and all([isinstance(b, (six.text_type, six.binary_type)) for b in body]):
+                for value in body:
+                    self._body.append(value)
+        elif body_type == constants.MessageBodyType.SequenceType:
+            self._body = SequenceBody(self._message)
+            if isinstance(body, list) and all([isinstance(b, list) for b in body]):
+                for value in body:
+                    self._body.append(value)
+            else:
+                self._body.append(body)
+        else:  # ValueType
+            self._body = ValueBody(self._message)
+            self._body.set(body)
 
     def _populate_message_attributes(self, c_message):
         if self.properties:
@@ -292,7 +352,6 @@ class Message(object):
             footer = c_uamqp.create_footer(
                 utils.data_factory(self.footer, encoding=self._encoding))
             c_message.footer = footer
-
 
     @property
     def settled(self):
@@ -1052,6 +1111,73 @@ class ValueBody(MessageBody):
         if _value:
             return _value.value
         return None
+
+
+class SequenceBody(MessageBody):
+    """An AMQP message body of type Sequence. This represents
+    a list of sequence sections.
+
+    :ivar type: The body type. This should always be SequenceType
+    :vartype type: uamqp.c_uamqp.MessageBodyType
+    :ivar data: The data contained in the message body. This returns
+     a generator to iterate over each section in the body, where
+     each section will be a list of objects.
+    :vartype data: Generator[List[object]]
+    """
+
+    def __str__(self):
+        if six.PY3:
+            output_str = ""
+            for sequence_section in self.data:
+                for d in sequence_section:
+                    if isinstance(d, six.binary_type):
+                        output_str += d.decode(self._encoding)
+                    else:
+                        output_str += str(d)
+            return output_str
+
+        return "".join(str(d) for sequence_section in self.data for d in sequence_section)
+
+    def __unicode__(self):
+        output_unicode = u""
+
+        for sequence_section in self.data:
+            for d in sequence_section:
+                if isinstance(d, six.binary_type):
+                    output_unicode += d.decode(self._encoding)
+                else:
+                    output_unicode += unicode(self.d)
+        return output_unicode
+
+    def __bytes__(self):
+        return b"".join(bytes(d) for sequence_section in self.data for d in sequence_section)
+
+    def __len__(self):
+        return self._message.count_body_sequence()
+
+    def __getitem__(self, index):
+        if index >= len(self):
+            raise IndexError("Index is out of range.")
+        data = self._message.get_body_sequence(index)
+        return data.value
+
+    def append(self, data):
+        """Append a sequence section to the body. The data
+        should be a list of objects. The object in the list
+        can be any Python data type and it will be automatically
+        encoded into an AMQP type. If a specific AMQP type
+        is required, a `types.AMQPType` can be used.
+
+        :param data: The list of objects to append.
+        :type data: list[~uamqp.types.AMQPType]
+        """
+        data = utils.data_factory(data)
+        self._message.add_body_sequence(data)
+
+    @property
+    def data(self):
+        for i in range(len(self)):
+            yield self._message.get_body_sequence(i).value
 
 
 class MessageHeader(object):

--- a/uamqp/message.py
+++ b/uamqp/message.py
@@ -281,38 +281,38 @@ class Message(object):
         """
         if isinstance(body, (six.text_type, six.binary_type)) or \
                 (isinstance(body, list) and all([isinstance(b, (six.text_type, six.binary_type)) for b in body])):
-            return constants.MessageBodyType.DataType
-        return constants.MessageBodyType.ValueType
+            return constants.MessageBodyType.Data
+        return constants.MessageBodyType.Value
 
     @staticmethod
     def _validate_body_and_body_type(body, body_type):
-        if body_type == constants.MessageBodyType.DataType:
+        if body_type == constants.MessageBodyType.Data:
             if not (isinstance(body, (six.text_type, six.binary_type)) or
                     (isinstance(body, list) and all([isinstance(b, (six.text_type, six.binary_type)) for b in body]))):
                 raise TypeError(
-                    "For MessageBodyType.DataType, the body"
+                    "For MessageBodyType.Data, the body"
                     " must be str or bytes or list of str or bytes.")
-        elif body_type == constants.MessageBodyType.SequenceType:
+        elif body_type == constants.MessageBodyType.Sequence:
             if not (isinstance(body, list) or
                     (isinstance(body, list) and all([isinstance(b, list) for b in body]))):
                 raise TypeError(
-                    "For MessageBodyType.SequenceType, the body"
+                    "For MessageBodyType.Sequence, the body"
                     " must be list or list of lists.")
-        elif body_type == constants.MessageBodyType.ValueType:
-            # For MessageBodyType.ValueType, the body could by any type.
+        elif body_type == constants.MessageBodyType.Value:
+            # For MessageBodyType.Value, the body could by any type.
             pass
         else:
             raise ValueError("Unsupported MessageBodyType: {}".format(body_type))
 
     def _set_body_by_body_type(self, body, body_type):
-        if body_type == constants.MessageBodyType.DataType:
+        if body_type == constants.MessageBodyType.Data:
             self._body = DataBody(self._message)
             if isinstance(body, (six.text_type, six.binary_type)):
                 self._body.append(body)
             elif isinstance(body, list) and all([isinstance(b, (six.text_type, six.binary_type)) for b in body]):
                 for value in body:
                     self._body.append(value)
-        elif body_type == constants.MessageBodyType.SequenceType:
+        elif body_type == constants.MessageBodyType.Sequence:
             self._body = SequenceBody(self._message)
             if isinstance(body, list) and all([isinstance(b, list) for b in body]):
                 for value in body:


### PR DESCRIPTION
- Based on the option1 design proposal: https://gist.github.com/yunhaoling/b7c30894f59542c70de589940a319460
- Added support for AMQP Sequence as the body type of the message.
- Added new class `uamqp.MessageBodyType` to denote the body type of an amqp message, including:
  - `DataType`: The body consists of one or more data sections and each section contains opaque binary data.
  - `SequenceType`: The body consists of one or more sequence sections and each section contains an arbitrary number of structured data elements.
  - `ValueType`: The body consists of one amqp-value section and the section contains a single AMQP value.
- Added new parameter `body_type` to the constructor of `uamqp.Message` which takes `uamqp.MessageBodyType` to denote the body type of an amqp message.
- Added support for sending/receiving message whose body consists of sequence into the c uamqp library