### PR TITLE
revert mem leak fix as it would break mgmt operation

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -19,7 +19,6 @@ This version will be the last version to officially support Python 3.5, future v
   - `delivery_annotations` which takes a dict to set the delivery annotations of an amqp message.
 - Fixed bug that sending message of large size triggering segmentation fault when the underlying socket connection is lost.
 - Fixed bug in link flow control where link credit and delivery count should be calculated based on per message instead of per transfer frame.
-- Fixed memory leaks in the process of link attach where source and target cython objects are not properly deallocated.
 
 1.2.15 (2021-03-02)
 +++++++++++++++++++

--- a/src/amqpvalue.pyx
+++ b/src/amqpvalue.pyx
@@ -891,7 +891,7 @@ cdef class CompositeValue(AMQPValue):
         if index >= self.size:
             raise IndexError("Index is out of range.")
         cdef c_amqpvalue.AMQP_VALUE value
-        value = c_amqpvalue.amqpvalue_get_composite_item(self._c_value, index)
+        value = c_amqpvalue.amqpvalue_get_composite_item_in_place(self._c_value, index)
         if <void*>value == NULL:
             self._value_error()
         try:

--- a/src/session.pyx
+++ b/src/session.pyx
@@ -148,7 +148,4 @@ cdef bint on_link_attached(
                 context_obj._attach_received(source_factory(wrapped_source), target_factory(wrapped_target), attach_properties, None)
         except Exception as e:
             _logger.info("Failed to process link ATTACH frame: %r", e)
-        finally:
-            c_amqpvalue.amqpvalue_destroy(cloned_source)
-            c_amqpvalue.amqpvalue_destroy(cloned_target)
     return True

--- a/src/source.pyx
+++ b/src/source.pyx
@@ -65,15 +65,11 @@ cdef class cSource(StructBase):
     @property
     def address(self):
         cdef c_amqpvalue.AMQP_VALUE _value
-        cdef c_amqpvalue.AMQP_VALUE cloned
         if c_amqp_definitions.source_get_address(self._c_value, &_value) != 0:
             self._value_error("Failed to get source address")
         if <void*>_value == NULL:
             return None
-        cloned = c_amqpvalue.amqpvalue_clone(_value)
-        if <void*>cloned == NULL:
-            return None
-        return value_factory(cloned).value
+        return value_factory(_value).value
 
     @address.setter
     def address(self, AMQPValue value):

--- a/src/target.pyx
+++ b/src/target.pyx
@@ -65,15 +65,11 @@ cdef class cTarget(StructBase):
     @property
     def address(self):
         cdef c_amqpvalue.AMQP_VALUE _value
-        cdef c_amqpvalue.AMQP_VALUE cloned
         if c_amqp_definitions.target_get_address(self._c_value, &_value) != 0:
             self._value_error("Failed to get target address")
         if <void*>_value == NULL:
             return None
-        cloned = c_amqpvalue.amqpvalue_clone(_value)
-        if <void*>cloned == NULL:
-            return None
-        return value_factory(cloned).value
+        return value_factory(_value).value
 
     @address.setter
     def address(self, AMQPValue value):


### PR DESCRIPTION
revert the change introduced by PR: https://github.com/Azure/azure-uamqp-python/pull/215/files excluding body sequence as it  is used by the body sequence feature and needs the fix.

here are the reason for the revert:

- normal receiver/sender links are good with the mem leak fix.
- however, mgmt operations on mgmt link would become unstable and either fail or report seg fault quite frequently (and of course, sometimes succeed) due to the mem leak fix.
- My guessing is that any of the target/source/properties (all of them are from an ATTACH performative) are referenced in the mgmt link (in c amqp_management module) somewhere and they need special treatment (ref counted incorrectly).

need more time for investigation.

 