### PR TITLE
handle connection discarding in sending

### DIFF
--- a/uamqp/client.py
+++ b/uamqp/client.py
@@ -648,6 +648,8 @@ class SendClient(AMQPClient):
         # pylint: disable=protected-access
         self.message_handler.work()
         self._connection.work()
+        if self._connection._state == c_uamqp.ConnectionState.DISCARDING:
+            raise errors.ConnectionClose(constants.ErrorCodes.InternalServerError)
         self._waiting_messages = 0
         self._pending_messages = self._filter_pending()
         if self._backoff and not self._waiting_messages:


### PR DESCRIPTION
this majorly addresses the issue that sending while in connection discarding state, previously connection would internally loop (from DISCARDING to DISCARDING) until socket finally fails.

now as we moved the connection dowork at the front of _client_run in send client so we're able to detect the DISCARDING state in advance and raise error for backward compatibility and improvement on the flow.

besides. according to AMQP spec, DISCARDING is a variant of CLOSE_SENT and TCP should close for write
