### PR TITLE
memory leak fix in cython link attach

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -3,7 +3,7 @@
 Release History
 ===============
 
-1.4.0 (Unreleased)
+1.4.0 (2021-05-03)
 +++++++++++++++++++
 
 This version and all future versions will require Python 2.7 or Python 3.6+, Python 3.5 is no longer supported.

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -3,6 +3,11 @@
 Release History
 ===============
 
+1.3.1 (Unreleased)
++++++++++++++++++++
+
+- Fixed memory leaks in the process of link attach where source and target cython objects are not properly deallocated.
+
 1.3.0 (2021-04-05)
 +++++++++++++++++++
 

--- a/src/amqpvalue.pyx
+++ b/src/amqpvalue.pyx
@@ -891,7 +891,7 @@ cdef class CompositeValue(AMQPValue):
         if index >= self.size:
             raise IndexError("Index is out of range.")
         cdef c_amqpvalue.AMQP_VALUE value
-        value = c_amqpvalue.amqpvalue_get_composite_item_in_place(self._c_value, index)
+        value = c_amqpvalue.amqpvalue_get_composite_item(self._c_value, index)
         if <void*>value == NULL:
             self._value_error()
         try:

--- a/src/session.pyx
+++ b/src/session.pyx
@@ -148,4 +148,7 @@ cdef bint on_link_attached(
                 context_obj._attach_received(source_factory(wrapped_source), target_factory(wrapped_target), attach_properties, None)
         except Exception as e:
             _logger.info("Failed to process link ATTACH frame: %r", e)
+        finally:
+            c_amqpvalue.amqpvalue_destroy(cloned_source)
+            c_amqpvalue.amqpvalue_destroy(cloned_target)
     return True

--- a/src/source.pyx
+++ b/src/source.pyx
@@ -65,11 +65,15 @@ cdef class cSource(StructBase):
     @property
     def address(self):
         cdef c_amqpvalue.AMQP_VALUE _value
+        cdef c_amqpvalue.AMQP_VALUE cloned
         if c_amqp_definitions.source_get_address(self._c_value, &_value) != 0:
             self._value_error("Failed to get source address")
         if <void*>_value == NULL:
             return None
-        return value_factory(_value).value
+        cloned = c_amqpvalue.amqpvalue_clone(_value)
+        if <void*>cloned == NULL:
+            return None
+        return value_factory(cloned).value
 
     @address.setter
     def address(self, AMQPValue value):
@@ -163,11 +167,15 @@ cdef class cSource(StructBase):
     @property
     def filter_set(self):
         cdef c_amqp_definitions.filter_set _value
+        cdef c_amqp_definitions.filter_set clone
         if c_amqp_definitions.source_get_filter(self._c_value, &_value) != 0:
             self._value_error("Failed to get source filter_set")
         if <void*>_value == NULL:
             return None
-        return value_factory(_value)
+        cloned = c_amqpvalue.amqpvalue_clone(_value)
+        if <void*>cloned == NULL:
+            return None
+        return value_factory(cloned)
 
     @filter_set.setter
     def filter_set(self, AMQPValue value):

--- a/src/target.pyx
+++ b/src/target.pyx
@@ -65,11 +65,15 @@ cdef class cTarget(StructBase):
     @property
     def address(self):
         cdef c_amqpvalue.AMQP_VALUE _value
+        cdef c_amqpvalue.AMQP_VALUE cloned
         if c_amqp_definitions.target_get_address(self._c_value, &_value) != 0:
             self._value_error("Failed to get target address")
         if <void*>_value == NULL:
             return None
-        return value_factory(_value).value
+        cloned = c_amqpvalue.amqpvalue_clone(_value)
+        if <void*>cloned == NULL:
+            return None
+        return value_factory(cloned).value
 
     @address.setter
     def address(self, AMQPValue value):

--- a/uamqp/__init__.py
+++ b/uamqp/__init__.py
@@ -35,7 +35,7 @@ except (SyntaxError, ImportError):
     pass  # Async not supported.
 
 
-__version__ = "1.3.0"
+__version__ = "1.3.1"
 
 
 _logger = logging.getLogger(__name__)


### PR DESCRIPTION
This is the following up PR on the previous memory leak fix: https://github.com/Azure/azure-uamqp-python/pull/215.

**Latest updates**

- The previous fix is incomplete and will leads to seg fault/mgmt operation failures on certain mgmt operations in service bus -- so we revert the change.
- Through investigation, I find that the `filter_set` on `cSource` in cython also needs to be cloned first as the c module won't clone it when we're getting the value.

--------------
**Previous context**

**Problem:**
- This PR is to address the memory issue in service bus client creation: https://github.com/Azure/azure-sdk-for-python/issues/15747.

**Root cause:**

Client creation would leak memory after connection and **session** is established because 
- in `on_link_attached` callback in `session.pyx`, `cloned_source` and `cloned_target` are not destroyed.

**How to Fix:**
- destroy `cloned_source` and `cloned_target` in a `finally` block in the callback.

**More:**
- found that there're two more places in src/amqpvalue.pyx and src/message.pyx where `value_factory` are not used properly. fixed them at the same time.

**Analysis:**

- The memory leak is within the [on_link_attached in session.pyx](https://github.com/Azure/azure-uamqp-python/blob/master/src/session.pyx#L116):
  - two c AMQP_VALUE are cloned while not being destroyed:    
    - cdef c_amqpvalue.AMQP_VALUE cloned_source
    - cdef c_amqpvalue.AMQP_VALUE cloned_target
    - destroying them in the `finally` could correctly decrease the reference count
    - **however random segmentation fault will be triggered.**
- after keeping investigation into how the properties on the source/targer are used, the `address` property is returned by [source_get_address](https://github.com/Azure/azure-uamqp-python/blob/e1051ae1c8f93ed2792a852857d261a4f34b76f5/src/vendor/azure-uamqp-c/src/amqp_definitions.c#L12347) which is a *in_memory* opeartion (value not cloned, reference count doesn't + 1), that seems to be place where seg fault took place
  - it cannot be simply wrapped by the cython AMQPValue (via `value_factory`), as AMQPValue will call destroy (reference count - 1) when GC kicks in. the reference count will be incorrect at that time.
  - it should be cloned first, we have other similar codes in amqpvalue.pyx when C *_in_memory methods are called
  - after fixing this, no seg fault happens
- I further searched where value_factory methods are used and found two more places that need fix
  - the `pop` method in cdef class CompositeValue(AMQPValue)
  - the `get_body_sequence` method in cdef class cMessage