### PR TITLE
fix windows python2.7 compiler in ci

### DIFF
--- a/.azure-pipelines/client.test.live.yml
+++ b/.azure-pipelines/client.test.live.yml
@@ -69,7 +69,7 @@ jobs:
           versionSpec: '$(PythonVersion)'
 
       - powershell: |
-          Invoke-WebRequest -UseBasicParsing -Uri $(python-uamqp-client-build-win-py27-compiler) -OutFile VCForPython27.msi
+          Invoke-WebRequest -UseBasicParsing -Uri "$(python-uamqp-client-build-win-py27-compiler)" -OutFile VCForPython27.msi
           Start-Process -Wait -NoNewWindow msiexec.exe -ArgumentList "/i VCForPython27.msi /quiet /qn /norestart /log VCForPython27.log ALLUSERS=1"
           Get-Content VCForPython27.log
         displayName: 'Install Microsoft Visual C++ Compiler for Python 2.7'

--- a/.azure-pipelines/client.test.live.yml
+++ b/.azure-pipelines/client.test.live.yml
@@ -68,8 +68,8 @@ jobs:
           architecture: '$(PythonArchitecture)'
           versionSpec: '$(PythonVersion)'
 
-      - powershell: |
-          Invoke-WebRequest -UseBasicParsing -Uri "$(python-uamqp-client-build-win-py27-compiler)" -OutFile VCForPython27.msi
+      - pwsh: |
+          Invoke-WebRequest -Uri "$(python-uamqp-client-build-win-py27-compiler)" -OutFile VCForPython27.msi
           Start-Process -Wait -NoNewWindow msiexec.exe -ArgumentList "/i VCForPython27.msi /quiet /qn /norestart /log VCForPython27.log ALLUSERS=1"
           Get-Content VCForPython27.log
         displayName: 'Install Microsoft Visual C++ Compiler for Python 2.7'

--- a/.azure-pipelines/client.test.live.yml
+++ b/.azure-pipelines/client.test.live.yml
@@ -69,7 +69,7 @@ jobs:
           versionSpec: '$(PythonVersion)'
 
       - powershell: |
-          Invoke-WebRequest -UseBasicParsing -Uri https://download.microsoft.com/download/7/9/6/796EF2E4-801B-4FC4-AB28-B59FBF6D907B/VCForPython27.msi -OutFile VCForPython27.msi
+          Invoke-WebRequest -UseBasicParsing -Uri $(python-uamqp-client-build-win-py27-compiler) -OutFile VCForPython27.msi
           Start-Process -Wait -NoNewWindow msiexec.exe -ArgumentList "/i VCForPython27.msi /quiet /qn /norestart /log VCForPython27.log ALLUSERS=1"
           Get-Content VCForPython27.log
         displayName: 'Install Microsoft Visual C++ Compiler for Python 2.7'

--- a/.azure-pipelines/client.yml
+++ b/.azure-pipelines/client.yml
@@ -206,7 +206,7 @@ jobs:
           versionSpec: '$(PythonVersion)'
 
       - powershell: |
-          Invoke-WebRequest -UseBasicParsing -Uri $(python-uamqp-client-build-win-py27-compiler) -OutFile VCForPython27.msi
+          Invoke-WebRequest -UseBasicParsing -Uri "$(python-uamqp-client-build-win-py27-compiler)" -OutFile VCForPython27.msi
           Start-Process -Wait -NoNewWindow msiexec.exe -ArgumentList "/i VCForPython27.msi /quiet /qn /norestart /log VCForPython27.log ALLUSERS=1"
           Get-Content VCForPython27.log
         displayName: 'Install Microsoft Visual C++ Compiler for Python 2.7'

--- a/.azure-pipelines/client.yml
+++ b/.azure-pipelines/client.yml
@@ -205,8 +205,8 @@ jobs:
           architecture: '$(PythonArchitecture)'
           versionSpec: '$(PythonVersion)'
 
-      - powershell: |
-          Invoke-WebRequest -UseBasicParsing -Uri "$(python-uamqp-client-build-win-py27-compiler)" -OutFile VCForPython27.msi
+      - pwsh: |
+          Invoke-WebRequest -Uri "$(python-uamqp-client-build-win-py27-compiler)" -OutFile VCForPython27.msi
           Start-Process -Wait -NoNewWindow msiexec.exe -ArgumentList "/i VCForPython27.msi /quiet /qn /norestart /log VCForPython27.log ALLUSERS=1"
           Get-Content VCForPython27.log
         displayName: 'Install Microsoft Visual C++ Compiler for Python 2.7'

--- a/.azure-pipelines/client.yml
+++ b/.azure-pipelines/client.yml
@@ -206,7 +206,7 @@ jobs:
           versionSpec: '$(PythonVersion)'
 
       - powershell: |
-          Invoke-WebRequest -UseBasicParsing -Uri https://download.microsoft.com/download/7/9/6/796EF2E4-801B-4FC4-AB28-B59FBF6D907B/VCForPython27.msi -OutFile VCForPython27.msi
+          Invoke-WebRequest -UseBasicParsing -Uri $(python-uamqp-client-build-win-py27-compiler) -OutFile VCForPython27.msi
           Start-Process -Wait -NoNewWindow msiexec.exe -ArgumentList "/i VCForPython27.msi /quiet /qn /norestart /log VCForPython27.log ALLUSERS=1"
           Get-Content VCForPython27.log
         displayName: 'Install Microsoft Visual C++ Compiler for Python 2.7'


### PR DESCRIPTION
problem: uamqp pipeline fail to build win27 wheel because vcpython27 installer being removed from the official site

potential approach to solve the issue:

- use the internal copy for building
- keep the copy in some private place like storage (or ci?)

tried steps:

1. upload the internal copy into a storage blob
2. add a key vault secret, value being the blob uri
3. configure ci variable group to include the secret
4. update yml to use the env variable for the blob uri


blocked:
- CI reporting resource not found, potentially AAD issue: the agent doesn't have access to that blob