### PR TITLE
revert amqp mgmt string type check to avoid log error when description is null

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -8,7 +8,7 @@ Release History
 
 This version and all future versions will require Python 2.7 or Python 3.6+, Python 3.5 is no longer supported.
 
-- Improved management operation callback not to parse description value of non AMQP_TYPE_STRING type as string.
+- Improved management operation callback not to parse description value of non AMQP_TYPE_STRING type as string (azure-sdk-for-python issue #18361).
 
 1.3.0 (2021-04-05)
 +++++++++++++++++++

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -8,6 +8,8 @@ Release History
 
 This version and all future versions will require Python 2.7 or Python 3.6+, Python 3.5 is no longer supported.
 
+- Improved management operation callback not to parse description value of type AMQP_TYPE_NULL as string.
+
 1.3.0 (2021-04-05)
 +++++++++++++++++++
 

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -8,7 +8,7 @@ Release History
 
 This version and all future versions will require Python 2.7 or Python 3.6+, Python 3.5 is no longer supported.
 
-- Improved management operation callback not to parse description value of type AMQP_TYPE_NULL as string.
+- Improved management operation callback not to parse description value of non AMQP_TYPE_STRING type as string.
 
 1.3.0 (2021-04-05)
 +++++++++++++++++++

--- a/src/vendor/azure-uamqp-c/src/amqp_management.c
+++ b/src/vendor/azure-uamqp-c/src/amqp_management.c
@@ -198,11 +198,15 @@ static AMQP_VALUE on_message_received(const void* context, MESSAGE_HANDLE messag
                                             desc_value = amqpvalue_get_map_value(map, desc_key);
                                             if (desc_value != NULL)
                                             {
-                                                /* Codes_SRS_AMQP_MANAGEMENT_01_134: [ The status description value shall be extracted from the value found in the map by using `amqpvalue_get_string`. ]*/
-                                                if (amqpvalue_get_string(desc_value, &status_description) != 0)
+                                                AMQP_TYPE amqp_type = amqpvalue_get_type(desc_value);
+                                                if (amqp_type == AMQP_TYPE_STRING)
                                                 {
-                                                    /* Codes_SRS_AMQP_MANAGEMENT_01_125: [ If status description is not found, NULL shall be passed to the user callback as `status_description` argument. ]*/
-                                                    status_description = NULL;
+                                                    /* Codes_SRS_AMQP_MANAGEMENT_01_134: [ The status description value shall be extracted from the value found in the map by using `amqpvalue_get_string`. ]*/
+                                                    if (amqpvalue_get_string(desc_value, &status_description) != 0)
+                                                    {
+                                                        /* Codes_SRS_AMQP_MANAGEMENT_01_125: [ If status description is not found, NULL shall be passed to the user callback as `status_description` argument. ]*/
+                                                        status_description = NULL;
+                                                    }
                                                 }
                                             }
                                             else

--- a/src/vendor/azure-uamqp-c/src/amqp_management.c
+++ b/src/vendor/azure-uamqp-c/src/amqp_management.c
@@ -208,6 +208,11 @@ static AMQP_VALUE on_message_received(const void* context, MESSAGE_HANDLE messag
                                                         status_description = NULL;
                                                     }
                                                 }
+                                                else
+                                                {
+                                                    /* Codes_SRS_AMQP_MANAGEMENT_01_125: [ If status description is not found, NULL shall be passed to the user callback as `status_description` argument. ]*/
+                                                    status_description = NULL;
+                                                }
                                             }
                                             else
                                             {


### PR DESCRIPTION
when servicebus mgmt operation succeeds, the service returns status code 200 and `desc_value` is of type `AMQP_TYPE_NULL`.
we should not call `amqpvalue_get_string` on a NULL type.

issue: https://github.com/Azure/azure-sdk-for-python/issues/18361#issuecomment-828727089

revert the following check in v1.2.13 to avoid the misleading error log. (not sure why the changes get ignored when I was updating the dependency..)

```
AMQP_TYPE amqp_type = amqpvalue_get_type(desc_value);
if (amqp_type == AMQP_TYPE_STRING)
{
...
}
```
see code in v1.2.13 here:
https://github.com/Azure/azure-uamqp-python/blob/v1.2.13/src/vendor/azure-uamqp-c/src/amqp_management.c#L201-L210
(originally from PR: https://github.com/Azure/azure-uamqp-python/pull/102)