### PR TITLE
fix memory leak in c on windows

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -5,7 +5,7 @@ Release History
 
 1.4.2 (Unreleased)
 
-- Fiexed memory leak in win32 socketio (azure-sdk-for-python issue #19777).
+- Fixed memory leak in win32 tlsio (azure-sdk-for-python issue #19777).
 
 1.4.1 (2021-06-28)
 +++++++++++++++++++

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -5,7 +5,7 @@ Release History
 
 1.4.2 (Unreleased)
 
-- Fixed memory leak in win32 tlsio (azure-sdk-for-python issue #19777).
+- Fixed memory leak in win32 socketio and tlsio (azure-sdk-for-python issue #19777).
 
 1.4.1 (2021-06-28)
 +++++++++++++++++++

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -3,6 +3,10 @@
 Release History
 ===============
 
+1.4.2 (Unreleased)
+
+- Fixed memory leaks in socket deallocation on Windows platform (azure-sdk-for-python issue #19777).
+
 1.4.1 (2021-06-28)
 +++++++++++++++++++
 

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -5,7 +5,7 @@ Release History
 
 1.4.2 (Unreleased)
 
-- Fixed memory leaks in socket deallocation on Windows platform (azure-sdk-for-python issue #19777).
+- Fiexed memory leak in win32 socketio (azure-sdk-for-python issue #19777).
 
 1.4.1 (2021-06-28)
 +++++++++++++++++++

--- a/src/vendor/azure-uamqp-c/deps/azure-c-shared-utility/adapters/socketio_win32.c
+++ b/src/vendor/azure-uamqp-c/deps/azure-c-shared-utility/adapters/socketio_win32.c
@@ -295,6 +295,7 @@ static void destroy_socket_io_instance(SOCKET_IO_INSTANCE* instance)
     }
 
     free(instance->hostname);
+    free(instance->addrInfo->ai_addr);
     free(instance->addrInfo);
 
     if (instance->pending_io_list != NULL)

--- a/src/vendor/azure-uamqp-c/deps/azure-c-shared-utility/adapters/socketio_win32.c
+++ b/src/vendor/azure-uamqp-c/deps/azure-c-shared-utility/adapters/socketio_win32.c
@@ -295,7 +295,6 @@ static void destroy_socket_io_instance(SOCKET_IO_INSTANCE* instance)
     }
 
     free(instance->hostname);
-    free(instance->addrInfo->ai_addr);
     free(instance->addrInfo);
 
     if (instance->pending_io_list != NULL)
@@ -360,12 +359,6 @@ CONCRETE_IO_HANDLE socketio_create(void* io_create_parameters)
                 else if ((result->addrInfo = calloc(1, sizeof(struct addrinfo))) == NULL)
                 {
                     LogError("Failure: addrInfo == NULL.");
-                    destroy_socket_io_instance(result);
-                    result = NULL;
-                }
-                else if ((result->addrInfo->ai_addr = calloc(1, sizeof(struct sockaddr_in))) == NULL)
-                {
-                    LogError("Failure allocating ai_addr");
                     destroy_socket_io_instance(result);
                     result = NULL;
                 }

--- a/src/vendor/azure-uamqp-c/deps/azure-c-shared-utility/adapters/tlsio_schannel.c
+++ b/src/vendor/azure-uamqp-c/deps/azure-c-shared-utility/adapters/tlsio_schannel.c
@@ -344,6 +344,7 @@ static void send_client_hello(TLS_IO_INSTANCE* tls_io_instance)
     {
         tls_io_instance->tlsio_state = TLSIO_STATE_ERROR;
         indicate_error(tls_io_instance);
+        (void)FreeCredentialHandle(&tls_io_instance->credential_handle);
     }
     else
     {
@@ -388,6 +389,8 @@ static void send_client_hello(TLS_IO_INSTANCE* tls_io_instance)
                 }
             }
         }
+        FreeContextBuffer(init_security_buffers[0].pvBuffer);
+        FreeContextBuffer(init_security_buffers[1].pvBuffer);
     }
 }
 
@@ -825,6 +828,8 @@ static void on_underlying_io_bytes_received(void* context, const unsigned char* 
                     }
                     break;
                 }
+                FreeContextBuffer(output_buffers[0].pvBuffer);
+                FreeContextBuffer(output_buffers[1].pvBuffer);
             }
             else if (tls_io_instance->tlsio_state == TLSIO_STATE_OPEN)
             {
@@ -965,6 +970,8 @@ static void on_underlying_io_bytes_received(void* context, const unsigned char* 
                             }
                         }
                     }
+                    FreeContextBuffer(output_buffers[0].pvBuffer);
+                    FreeContextBuffer(output_buffers[1].pvBuffer);
                     break;
                 }
 

--- a/src/vendor/azure-uamqp-c/deps/azure-c-shared-utility/adapters/tlsio_schannel.c
+++ b/src/vendor/azure-uamqp-c/deps/azure-c-shared-utility/adapters/tlsio_schannel.c
@@ -344,7 +344,6 @@ static void send_client_hello(TLS_IO_INSTANCE* tls_io_instance)
     {
         tls_io_instance->tlsio_state = TLSIO_STATE_ERROR;
         indicate_error(tls_io_instance);
-        (void)FreeCredentialHandle(&tls_io_instance->credential_handle);
     }
     else
     {

--- a/src/vendor/azure-uamqp-c/deps/azure-c-shared-utility/tests/socketio_win32_ut/socketio_win32_ut.c
+++ b/src/vendor/azure-uamqp-c/deps/azure-c-shared-utility/tests/socketio_win32_ut/socketio_win32_ut.c
@@ -506,7 +506,6 @@ TEST_FUNCTION(socketio_create_succeeds)
     EXPECTED_CALL(singlylinkedlist_create());
     EXPECTED_CALL(gballoc_malloc(IGNORED_NUM_ARG));
     EXPECTED_CALL(gballoc_calloc(IGNORED_NUM_ARG, IGNORED_NUM_ARG));
-    EXPECTED_CALL(gballoc_calloc(IGNORED_NUM_ARG, IGNORED_NUM_ARG));
     EXPECTED_CALL(gballoc_malloc(IGNORED_NUM_ARG));
     EXPECTED_CALL(gballoc_malloc(IGNORED_NUM_ARG));
 


### PR DESCRIPTION
1. **`result->addrInfo->ai_addr = calloc(1, sizeof(struct sockaddr_in))) == NULL` should no longer exist according to cuamqp
echoing the change in PR: https://github.com/Azure/azure-c-shared-utility/pull/515**

----------------------

2. **The PR to fix the following memory leak issue has been merged already: https://github.com/Azure/azure-c-shared-utility/pull/540**

- output buffer should be freed manually

https://github.com/Azure/azure-uamqp-python/blob/4558df974fa1a483cf5f0eaf7fe32af465292a50/src/vendor/azure-uamqp-c/deps/azure-c-shared-utility/adapters/tlsio_schannel.c#L298

by:

```c
        FreeContextBuffer(init_security_buffers[0].pvBuffer);
        FreeContextBuffer(init_security_buffers[1].pvBuffer);
```

because the flag `ISC_REQ_ALLOCATE_MEMORY` is used in code:
https://github.com/Azure/azure-uamqp-python/blob/4558df974fa1a483cf5f0eaf7fe32af465292a50/src/vendor/azure-uamqp-c/deps/azure-c-shared-utility/adapters/tlsio_schannel.c#L365-L368
```
ISC_REQ_ALLOCATE_MEMORY | The [*security package*](../secgloss/s-gly.md) allocates output buffers for you. When you have finished using the output buffers, free them by calling the [FreeContextBuffer](/windows/win32/api/sspi/nf-sspi-freecontextbuffer) function.
```

according to
https://docs.microsoft.com/en-us/windows/win32/secauthn/initializesecuritycontext--schannel