### PR TITLE
fix mem leak in converting amqp value into string

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -3,6 +3,11 @@
 Release History
 ===============
 
+1.4.2 (Unreleased)
++++++++++++++++++++
+
+- Fixed memory leak in the process of converting AMQPValue into string.
+
 1.4.1 (2021-06-28)
 +++++++++++++++++++
 

--- a/src/amqpvalue.pyx
+++ b/src/amqpvalue.pyx
@@ -313,7 +313,10 @@ cdef class AMQPValue(StructBase):
         if <void*>value == NULL:
             self._value_error()
         as_string = c_amqpvalue.amqpvalue_to_string(value)
+        if <void*>as_string == NULL:
+            self._value_error()
         py_string = copy.deepcopy(as_string)
+        free(as_string)
         c_amqpvalue.amqpvalue_destroy(self._c_value)
         return py_string
 

--- a/src/amqpvalue.pyx
+++ b/src/amqpvalue.pyx
@@ -313,9 +313,7 @@ cdef class AMQPValue(StructBase):
         if <void*>value == NULL:
             self._value_error()
         as_string = c_amqpvalue.amqpvalue_to_string(value)
-        if <void*>as_string == NULL:
-            self._value_error()
-        py_string = copy.deepcopy(as_string)
+        py_string = <bytes> as_string
         free(as_string)
         c_amqpvalue.amqpvalue_destroy(self._c_value)
         return py_string

--- a/uamqp/__init__.py
+++ b/uamqp/__init__.py
@@ -35,7 +35,7 @@ except (SyntaxError, ImportError):
     pass  # Async not supported.
 
 
-__version__ = "1.4.1"
+__version__ = "1.4.2"
 
 
 _logger = logging.getLogger(__name__)


### PR DESCRIPTION
`amqpvalue_to_string` will malloc memory for the string, we should free the c allocated memory after usage.

according to cython, https://cython.readthedocs.io/en/latest/src/tutorial/strings.html, we could copy the c string into python string first, then we should be able to safely free the c string and let python take over the life management of the python string.