### PR TITLE
specify client.yaml py2.7 to use an image that contains py2.7

### DIFF
--- a/.azure-pipelines/client.yml
+++ b/.azure-pipelines/client.yml
@@ -334,11 +334,11 @@ jobs:
           PythonVersion: 'cp39-cp39'
           Platform: 'manylinux1_x86_64'
         Python27m-manylinux2010:
-          ContainerImage: 'manylinux2010_crypto_x64'
+          ContainerImage: 'manylinux2010_crypto_x64:3.9'
           PythonVersion: 'cp27-cp27m'
           Platform: 'manylinux2010_x86_64'
         Python27mu-manylinux2010:
-          ContainerImage: 'manylinux2010_crypto_x64'
+          ContainerImage: 'manylinux2010_crypto_x64:3.9'
           PythonVersion: 'cp27-cp27mu'
           Platform: 'manylinux2010_x86_64'
         Python36m-manylinux2010:


### PR DESCRIPTION
the latest manylinux 2010 (with python 3.10rc one) has dropped support for python 2.7

##[error]Status: Downloaded newer image for azuresdkimages.azurecr.io/manylinux2010_crypto_x64:latest
##[error]/data/build_many_linux.sh: line 19: /opt/python/cp27-cp27m/bin/pip: No such file or directory
##[error]The process '/usr/bin/docker' failed with exit code 1

related issue: https://github.com/Azure/azure-uamqp-python/pull/271