### PR TITLE
Lock.acquire in async connection not awaited

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -7,7 +7,7 @@ Release History
 +++++++++++++++++++
 
 - `SASTokenAuth`, `JWTTokenAuth`, `SASTokenAsync`, and `JWTTokenAsync` now takes keyword argument `refresh_window` to override default token refresh timing in constructors.
-- Fixed bug for `coroutine 'Lock.acquire' was never awaited` warning.
+- Fixed bug for `coroutine 'Lock.acquire' was never awaited` warning (azure-sdk-for-python issue #21639).
 
 1.4.3 (2021-10-06)
 +++++++++++++++++++

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -7,6 +7,7 @@ Release History
 +++++++++++++++++++
 
 - `SASTokenAuth`, `JWTTokenAuth`, `SASTokenAsync`, and `JWTTokenAsync` now takes keyword argument `refresh_window` to override default token refresh timing in constructors.
+- Fixed bug for `coroutine 'Lock.acquire' was never awaited` warning.
 
 1.4.3 (2021-10-06)
 +++++++++++++++++++

--- a/uamqp/async_ops/connection_async.py
+++ b/uamqp/async_ops/connection_async.py
@@ -108,7 +108,7 @@ class ConnectionAsync(connection.Connection):
         return self._internal_kwargs.get("loop")
 
     async def lock_async(self, timeout=3.0):
-        await asyncio.wait_for(self._async_lock.acquire(), timeout=timeout, **self._internal_kwargs)
+        await asyncio.wait_for(await self._async_lock.acquire(), timeout=timeout, **self._internal_kwargs)
 
     def release_async(self):
         try:


### PR DESCRIPTION
fixes: https://github.com/Azure/azure-sdk-for-python/issues/21639