### PR TITLE
Fix thread not started error

### DIFF
--- a/uamqp/client.py
+++ b/uamqp/client.py
@@ -260,7 +260,11 @@ class AMQPClient(object):
             self._build_session()
             if self._keep_alive_interval:
                 self._keep_alive_thread = threading.Thread(target=self._keep_alive)
-                self._keep_alive_thread.start()
+                try:
+                    self._keep_alive_thread.start()
+                except RuntimeError:
+                    self._keep_alive_thread = None
+                    raise
         finally:
             if self._ext_connection:
                 connection.release()


### PR DESCRIPTION
We keep getting errors from our code that a thread has not started while trying to `.join()` it on line 285.

Most likely the thread failed to start, which throws a `RuntimeError`, then the azure library catches the error and calls the `close()` method. At this point, the thread has been assigned to the attribute, but has failed to start, which causes the code to call `.join()` and error.

Proposed solution is to reset the attribute to `None` when such an error occurs.