### PR TITLE
[pyproto] unify to use second as unit

### DIFF
--- a/uamqp/cbs.py
+++ b/uamqp/cbs.py
@@ -207,6 +207,6 @@ class CBSAuthenticator(object):
         elif self.auth_state == CbsAuthState.Error:
             raise TokenAuthFailure(self._token_status_code, self._token_status_description, self._encoding)
         elif self.auth_state == CbsAuthState.Timeout:
-            raise TimeoutError("Authentication attempt timed-out.")  # TODO: compat 2.7 timeout error?
+            raise TimeoutError("Authentication attempt timed-out.")
         elif self.auth_state == CbsAuthState.Expired:
             raise TokenExpired("CBS Authentication Expired.")

--- a/uamqp/client.py
+++ b/uamqp/client.py
@@ -81,7 +81,7 @@ class AMQPClient(object):
     :type max_frame_size: int
     :param channel_max: Maximum number of Session channels in the Connection.
     :type channel_max: int
-    :param idle_timeout: Timeout in milliseconds after which the Connection will close
+    :param idle_timeout: Timeout in seconds after which the Connection will close
      if there is no further activity.
     :type idle_timeout: int
     :param auth_timeout: Timeout in seconds for CBS authentication. Otherwise this value will be ignored.
@@ -459,10 +459,6 @@ class ReceiveClient(AMQPClient):
     :param debug: Whether to turn on network trace logs. If `True`, trace logs
      will be logged at INFO level. Default is `False`.
     :type debug: bool
-    :param timeout: A timeout in milliseconds. The receiver will shut down if no
-     new messages are received after the specified timeout. If set to 0, the receiver
-     will never timeout and will continue to listen. The default is 0.
-    :type timeout: float
     :param auto_complete: Whether to automatically settle message received via callback
      or via iterator. If the message has not been explicitly settled after processing
      the message will be accepted. Alternatively, when used with batch receive, this setting
@@ -505,7 +501,7 @@ class ReceiveClient(AMQPClient):
     :type max_frame_size: int
     :param channel_max: Maximum number of Session channels in the Connection.
     :type channel_max: int
-    :param idle_timeout: Timeout in milliseconds after which the Connection will close
+    :param idle_timeout: Timeout in seconds after which the Connection will close
      if there is no further activity.
     :type idle_timeout: int
     :param properties: Connection properties.
@@ -618,7 +614,7 @@ class ReceiveClient(AMQPClient):
         :param on_message_received: A callback to process messages as they arrive from the
          service. It takes a single argument, a ~uamqp.message.Message object.
         :type on_message_received: callable[~uamqp.message.Message]
-        :param timeout: I timeout in milliseconds for which to wait to receive any messages.
+        :param timeout: I timeout in seconds for which to wait to receive any messages.
          If no messages are received in this time, an empty list will be returned. If set to
          0, the client will continue to wait until at least one message is received. The
          default is 0.

--- a/uamqp/management_link.py
+++ b/uamqp/management_link.py
@@ -198,7 +198,7 @@ class ManagementLink(object):
         :paramtype type: bytes or str
         :keyword str locales: A list of locales that the sending peer permits for incoming
          informational text in response messages.
-        :keyword float timeout: Provide an optional timeout in milliseconds within which a response
+        :keyword float timeout: Provide an optional timeout in seconds within which a response
          to the management request must be received.
         :rtype: None
         """


### PR DESCRIPTION
it turns out that only docs need to be updated, implementations are correctly using seconds as the unit :)