### PR TITLE
add getstate/setstate to BatchMessage for deepcopy

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -3,6 +3,11 @@
 Release History
 ===============
 
+1.5.2 (Unreleased)
++++++++++++++++++++
+
+- Fixed bug that resulted in an error when deepcopying BatchMessage objects (azure-sdk-for-python issue #22529).
+
 1.5.1 (2022-01-12)
 +++++++++++++++++++
 

--- a/uamqp/__init__.py
+++ b/uamqp/__init__.py
@@ -35,7 +35,7 @@ except (SyntaxError, ImportError):
     pass  # Async not supported.
 
 
-__version__ = "1.5.1"
+__version__ = "1.5.2"
 
 
 _logger = logging.getLogger(__name__)

--- a/uamqp/message.py
+++ b/uamqp/message.py
@@ -646,6 +646,13 @@ class BatchMessage(Message):
         self._header = header
         self._need_further_parse = False
 
+    def __getstate__(self):
+        state = self.__dict__.copy()
+        return state
+
+    def __setstate__(self, state):
+        self.__dict__.update(state)
+
     def _create_batch_message(self):
         """Create a ~uamqp.message.Message for a value supplied by the data
         generator. Applies all properties and annotations to the message.


### PR DESCRIPTION
following up on this issue: https://github.com/Azure/azure-sdk-for-python/issues/22529

reason: BatchMessage inherits from Message, so it uses inherited `__getstate__`/`__setstate__`. `__getstate__` calls the `state` property on the object, which Message has but BatchMessage does not. Overriding `__getstate__`/`__setstate__` on BatchMessage.