### PR TITLE
build using windows 2019 image and vs 2019

### DIFF
--- a/.azure-pipelines/client.test.live.yml
+++ b/.azure-pipelines/client.test.live.yml
@@ -13,7 +13,7 @@ jobs:
   - job: 'Windows'
 
     pool:
-      vmImage: 'vs2017-win2016'
+      vmImage: 'windows-2019'
 
     timeoutInMinutes: 120
 

--- a/.azure-pipelines/client.yml
+++ b/.azure-pipelines/client.yml
@@ -147,7 +147,7 @@ jobs:
   - job: 'Windows'
 
     pool:
-      vmImage: 'vs2017-win2016'
+      vmImage: 'windows-2019'
 
     strategy:
       matrix:

--- a/setup.py
+++ b/setup.py
@@ -93,7 +93,7 @@ def get_build_env():
 def get_generator_flags():
     flags = ["-G"]
     if is_win:
-        flags.append("\"Visual Studio 15 2017\"")
+        flags.append("\"Visual Studio 16 2019\"")
         flags.append("-A")
         flags.append("ARM64" if platform.machine() == "ARM64" else "x64" if is_x64 else "Win32")
     else:


### PR DESCRIPTION
update using windows 2019 because:

- windows 2016 is dead and not available anymore: https://github.com/actions/virtual-environments/issues/4312
- not using windows 2022 because it doesn't support python3.6: https://github.com/actions/virtual-environments/blob/main/images/win/Windows2022-Readme.md

<img width="666" alt="image" src="https://user-images.githubusercontent.com/47871814/159381009-ff0cd475-5988-430e-b046-cd93369604ad.png">


update using vs 2019 as windows 2019 only provides vs 2019