### PR TITLE
Build macOS wheels for x64 and ARM

### DIFF
--- a/.github/workflows/wheel.yml
+++ b/.github/workflows/wheel.yml
@@ -1,0 +1,28 @@
+name: Wheels
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  build_wheels:
+    name: Build wheels on ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: ["macos-11"]
+        # os: ["macos-11", ubuntu-20.04, "windows-latest"]
+
+    steps:
+      - uses: actions/checkout@v3
+      - name: Build wheels
+        uses: pypa/cibuildwheel@v2.6.1
+        env:
+          CIBW_PRERELEASE_PYTHONS: True
+          CIBW_ARCHS_MACOS: x86_64 universal2
+      - uses: actions/upload-artifact@v2
+        with:
+          path: ./wheelhouse/*.whl

--- a/dev_requirements.txt
+++ b/dev_requirements.txt
@@ -7,3 +7,4 @@ pytest-asyncio==0.12.0; python_version >= '3.7'
 docutils>=0.14
 pygments>=2.2.0
 pylint==2.3.1; python_version >= '3.7'
+cibuildwheel

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,25 @@
+[build-system]
+requires = [
+    "setuptools>=42",
+    "wheel",
+    "Cython",
+    "cmake",
+]
+
+[tool.cibuildwheel]
+# skip musl and pypy
+skip = ["*-musllinux*", "pp*"] 
+test-requires = "pytest"
+test-command = "python -X dev -m pytest {project}/tests"
+
+[tool.cibuildwheel.macos.environment]
+MACOSX_DEPLOYMENT_TARGET = "10.9"
+CMAKE_OSX_DEPLOYMENT_TARGET = "10.9"
+CMAKE_OSX_ARCHITECTURES = "x86_64"
+UAMQP_USE_OPENSSL = true
+UAMQP_REBUILD_PYX = true
+UAMQP_SUPPRESS_LINK_FLAGS = true
+OPENSSL_ROOT_DIR = "/tmp/openssl"
+OPENSSL_INCLUDE_DIR = "/tmp/openssl/include"
+LDFLAGS = "-mmacosx-version-min=10.9 -L/tmp/openssl/lib"
+CFLAGS = "-mmacosx-version-min=10.9 -I/tmp/openssl/include"


### PR DESCRIPTION
This PR introduces the cibuildwheel project by PyPA as an easier solution for building wheels across many architectures.

It supports, macOS, Linux and Windows and would remove a lot of scripts and templates from this project.

I've just enabled macOS, but in the CI flow you can see it can do Linux and Windows. For Linux it will compile manylinux and manylinux2014 wheels.

The macOS compiler works with ARM/M1 on GitHub Actions.

The addition of "cmake" and "cython" to `pyproject.toml` removes the requirement for a custom docker container with cmake preinstalled.