### PR TITLE
Add in Linux wheels support for cibuildwheel

### DIFF
--- a/.github/workflows/wheel.yml
+++ b/.github/workflows/wheel.yml
@@ -13,8 +13,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: ["macos-11"]
-        # os: ["macos-11", ubuntu-20.04, "windows-latest"]
+        os: ["macos-11","windows-2019","ubuntu-18.04"]
 
     steps:
       - uses: actions/checkout@v3

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,3 +23,7 @@ OPENSSL_ROOT_DIR = "/tmp/openssl"
 OPENSSL_INCLUDE_DIR = "/tmp/openssl/include"
 LDFLAGS = "-mmacosx-version-min=10.9 -L/tmp/openssl/lib"
 CFLAGS = "-mmacosx-version-min=10.9 -I/tmp/openssl/include"
+
+[tool.cibuildwheel.linux]
+before-build = "apt-get install -y build-essential libssl-dev uuid-dev cmake libcurl4-openssl-dev pkg-config"
+environment = {OPENSSL_ROOT_DIR="/opt/pyca/cryptography/openssl", LIBRARY_PATH="/opt/pyca/cryptography/openssl/lib", CPATH="/opt/pyca/cryptography/openssl/include"}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,8 +9,8 @@ requires = [
 [tool.cibuildwheel]
 # skip musl and pypy
 skip = ["*-musllinux*", "pp*"] 
-test-requires = "pytest"
-test-command = "python -X dev -m pytest {project}/tests"
+#test-requires = "pytest"
+#test-command = "python -X dev -m pytest {project}/tests"
 
 [tool.cibuildwheel.macos.environment]
 MACOSX_DEPLOYMENT_TARGET = "10.9"
@@ -25,5 +25,7 @@ LDFLAGS = "-mmacosx-version-min=10.9 -L/tmp/openssl/lib"
 CFLAGS = "-mmacosx-version-min=10.9 -I/tmp/openssl/include"
 
 [tool.cibuildwheel.linux]
-before-build = "apt-get install -y build-essential libssl-dev uuid-dev cmake libcurl4-openssl-dev pkg-config"
+archs = ["x86_64"]
+manylinux-x86_64-image = "manylinux2014"
+before-build = "bash utils/install_openssl.sh"
 environment = {OPENSSL_ROOT_DIR="/opt/pyca/cryptography/openssl", LIBRARY_PATH="/opt/pyca/cryptography/openssl/lib", CPATH="/opt/pyca/cryptography/openssl/include"}

--- a/utils/install_openssl.sh
+++ b/utils/install_openssl.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+set -xe
+
+OPENSSL_URL="https://www.openssl.org/source/"
+
+export OPENSSL_VERSION="openssl-1.1.1n"
+export OPENSSL_SHA256="40dceb51a4f6a5275bde0e6bf20ef4b91bfc32ed57c0552e2e8e15463372b17a"
+# We need a base set of flags because on Windows using MSVC
+# enable-ec_nistp_64_gcc_128 doesn't work since there's no 128-bit type
+export OPENSSL_BUILD_FLAGS_WINDOWS="no-ssl3 no-ssl3-method no-zlib no-shared no-comp no-dynamic-engine"
+export OPENSSL_BUILD_FLAGS="${OPENSSL_BUILD_FLAGS_WINDOWS} enable-ec_nistp_64_gcc_128"
+
+function check_sha256sum {
+    local fname=$1
+    local sha256=$2
+    echo "${sha256}  ${fname}" > "${fname}.sha256"
+    sha256sum -c "${fname}.sha256"
+    rm "${fname}.sha256"
+}
+
+curl -#O "${OPENSSL_URL}/${OPENSSL_VERSION}.tar.gz"
+check_sha256sum ${OPENSSL_VERSION}.tar.gz ${OPENSSL_SHA256}
+tar zxf ${OPENSSL_VERSION}.tar.gz
+PATH=/opt/perl/bin:$PATH
+pushd ${OPENSSL_VERSION}
+./config $OPENSSL_BUILD_FLAGS --prefix=/opt/pyca/cryptography/openssl --openssldir=/opt/pyca/cryptography/openssl
+make depend
+make -j4
+# avoid installing the docs
+# https://github.com/openssl/openssl/issues/6685#issuecomment-403838728
+make install_sw install_ssldirs
+popd
+rm -rf openssl*


### PR DESCRIPTION
Adding in Linux support to cibuild wheel. This PR will allow for wheels to be created across Windows, macOS and Linux for py 3.7 to 3.11 using ManyLinux2014. 

Thank you @tonybaloney for his earlier PR to enable macOS support and introducing me to cibuildwheel :)

quirk: while the pytest command works for Win & macOS, it was failing on Linux as it was looking to pip install from constraints.txt, which is not present in this repo. 

moved up the openssl_install script at the utils level.
