### PR TITLE
default port handling

### DIFF
--- a/uamqp/authentication/common.py
+++ b/uamqp/authentication/common.py
@@ -170,7 +170,7 @@ class SASLPlain(AMQPAuth):
     """
 
     def __init__(
-            self, hostname, username, password, port=constants.DEFAULT_AMQPS_PORT,
+            self, hostname, username, password, port=None,
             verify=None, http_proxy=None, transport_type=TransportType.Amqp, encoding='UTF-8'):
         self._encoding = encoding
         self.hostname = self._encode(hostname)
@@ -206,7 +206,7 @@ class SASLAnonymous(AMQPAuth):
     :type encoding: str
     """
 
-    def __init__(self, hostname, port=constants.DEFAULT_AMQPS_PORT, verify=None,
+    def __init__(self, hostname, port=None, verify=None,
                  http_proxy=None, transport_type=TransportType.Amqp, encoding='UTF-8'):
         self._encoding = encoding
         self.hostname = self._encode(hostname)


### PR DESCRIPTION
Update default port handling for  (amqp / amap over websocket).
Set the default port for websocket to 443
Thi should fix the bug in #355 