### PR TITLE
Use correct test proxy storage location in Mac/Linux pipeline jobs

### DIFF
--- a/.azure-pipelines/test-proxy-tool.yml
+++ b/.azure-pipelines/test-proxy-tool.yml
@@ -48,7 +48,7 @@ steps:
 
     # nohup does NOT continue beyond the current session if you use it within powershell
     - bash: |
-        nohup $(Build.BinariesDirectory)/test-proxy/test-proxy > ${{ parameters.templateRoot }}/test-proxy.log &
+        nohup $(Build.BinariesDirectory)/test-proxy/test-proxy --storage-location ${{ parameters.rootFolder }} > ${{ parameters.templateRoot }}/test-proxy.log &
       displayName: "Run the testproxy - linux/mac"
       condition: and(succeeded(), ne(variables['Agent.OS'],'Windows_NT'), ${{ parameters.condition }})
 


### PR DESCRIPTION
### Context

Mac and Ubuntu pipeline runs [have been failing](https://dev.azure.com/azure-sdk/internal/_build/results?buildId=2154590&view=results) for Service Bus because the [`assets.json` file path](https://dev.azure.com/azure-sdk/internal/_build/results?buildId=2154590&view=logs&j=f6779834-8019-576e-5e70-ab3ce42c5ae8&t=5d72d164-b946-5b78-5436-76fc11aa74c2&l=7070) that's being used to find recordings is incorrect:
```
azure.core.exceptions.HttpResponseError: {"Message":"The provided assets.json path of \u0022/Users/runner/work/1/s/sdk/servicebus/azure-servicebus/assets.json\u0022 does not exist.","Status":"BadRequest"}
```

The problem is that the test proxy is looking for `azure-servicebus/assets.json` under `/Users/runner/work/1/s/sdk/servicebus` instead of `/Users/runner/work/1/s/azure-sdk-for-python/sdk/servicebus`. After some debugging, it turned out that Windows and Mac/Linux jobs were all providing the same [`assets.json` path](https://dev.azure.com/azure-sdk/internal/_build/results?buildId=2158820&view=logs&j=03a211a9-9c6f-5c84-2ea6-516160a0e0af&t=1eeacdd2-6543-5a0e-b2c5-2e8fe085458e&l=6779), relative to the `azure-sdk-for-python` root, to the test proxy at the same section of [devtools_testutils/proxy_testcase.py](https://github.com/Azure/azure-sdk-for-python/blob/f538be597733e6bd040831fc977bb881228a2830/tools/azure-sdk-tools/devtools_testutils/proxy_testcase.py#L83):
```
sdk/servicebus/azure-servicebus/assets.json
```

The full path that the test proxy uses is this provided `assets.json` path, appended to the tool's storage location. The problem, then, was that the test proxy itself was being provided with the correct `--storage-location` argument for Windows jobs but not for Mac/Linux jobs. This PR resolves this after verifying the changes with this pipeline run: https://dev.azure.com/azure-sdk/internal/_build/results?buildId=2162498&view=results