### PR TITLE
Update cibuildwheel to compile wheels for Python 3.12

### DIFF
--- a/.github/workflows/wheel.yml
+++ b/.github/workflows/wheel.yml
@@ -18,7 +18,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Build wheels
-        uses: pypa/cibuildwheel@v2.6.1
+        uses: pypa/cibuildwheel@v2.16.2
         env:
           CIBW_PRERELEASE_PYTHONS: True
           CIBW_ARCHS_MACOS: x86_64 universal2


### PR DESCRIPTION
Fixes #368 