### PR TITLE
Update uAMQP vendor

### DIFF
--- a/.azure-pipelines/client.test.live.yml
+++ b/.azure-pipelines/client.test.live.yml
@@ -29,22 +29,22 @@ jobs:
           PythonArchitecture: 'x64'
           PythonVersion: '$(PythonVersion38)'
           BWFilter: 'cp38-win_amd64'
-        x64 Python 3.9:
-          PythonArchitecture: 'x64'
-          PythonVersion: '$(PythonVersion39)'
-          BWFilter: 'cp39-win_amd64'
-        x64 Python 3.10:
-          PythonArchitecture: 'x64'
-          PythonVersion: '$(PythonVersion310)'
-          BWFilter: 'cp310-win_amd64'
-        x64 Python 3.11:
-          PythonArchitecture: 'x64'
-          PythonVersion: '$(PythonVersion311)'
-          BWFilter: 'cp311-win_amd64'
-        x64 Python 3.12:
-          PythonArchitecture: 'x64'
-          PythonVersion: '$(PythonVersion312)'
-          BWFilter: 'cp312-win_amd64'
+        #x64 Python 3.9:
+        #  PythonArchitecture: 'x64'
+        #  PythonVersion: '$(PythonVersion39)'
+        #  BWFilter: 'cp39-win_amd64'
+        #x64 Python 3.10:
+        #  PythonArchitecture: 'x64'
+        #  PythonVersion: '$(PythonVersion310)'
+        #  BWFilter: 'cp310-win_amd64'
+        #x64 Python 3.11:
+        #  PythonArchitecture: 'x64'
+        #  PythonVersion: '$(PythonVersion311)'
+        #  BWFilter: 'cp311-win_amd64'
+        #x64 Python 3.12:
+        #  PythonArchitecture: 'x64'
+        #  PythonVersion: '$(PythonVersion312)'
+        #  BWFilter: 'cp312-win_amd64'
             
     steps:
       - template: /.azure-pipelines/use-python-version.yml
@@ -128,224 +128,224 @@ jobs:
           artifactName: uamqp-win$(PythonArchitecture)-$(PythonVersion)-whl
           pathToPublish: 'dist'
 
-  - job: 'MacOS'
+  #- job: 'MacOS'
 
-    timeoutInMinutes: 120
+  #  timeoutInMinutes: 120
 
-    dependsOn: 'Windows'
+  #  dependsOn: 'Windows'
 
-    pool:
-      vmImage: 'macos-latest'
+  #  pool:
+  #    vmImage: 'macos-latest'
 
-    strategy:
-      maxParallel: 1
-      matrix:
-        Python 3.8:
-          PythonBin: 'python3'
-          PythonVersion: '$(PythonVersion38)'
-          BWFilter: 'cp38-macosx_x86_64'
-        Python 3.9:
-          PythonBin: 'python3'
-          PythonVersion: '$(PythonVersion39)'
-          BWFilter: 'cp39-macosx_x86_64'
-        Python 3.10:
-          PythonBin: 'python3'
-          PythonVersion: '$(PythonVersion310)'
-          BWFilter: 'cp310-macosx_x86_64'
-        Python 3.11:
-          PythonBin: 'python3'
-          PythonVersion: '$(PythonVersion311)'
-          BWFilter: 'cp311-macosx_x86_64'
-        Python 3.12:
-          PythonBin: 'python3'
-          PythonVersion: '$(PythonVersion312)'
-          BWFilter: 'cp312-macosx_x86_64'
+  #  strategy:
+  #    maxParallel: 1
+  #    matrix:
+  #      Python 3.8:
+  #        PythonBin: 'python3'
+  #        PythonVersion: '$(PythonVersion38)'
+  #        BWFilter: 'cp38-macosx_x86_64'
+  #      Python 3.9:
+  #        PythonBin: 'python3'
+  #        PythonVersion: '$(PythonVersion39)'
+  #        BWFilter: 'cp39-macosx_x86_64'
+  #      Python 3.10:
+  #        PythonBin: 'python3'
+  #        PythonVersion: '$(PythonVersion310)'
+  #        BWFilter: 'cp310-macosx_x86_64'
+  #      Python 3.11:
+  #        PythonBin: 'python3'
+  #        PythonVersion: '$(PythonVersion311)'
+  #        BWFilter: 'cp311-macosx_x86_64'
+  #      Python 3.12:
+  #        PythonBin: 'python3'
+  #        PythonVersion: '$(PythonVersion312)'
+  #        BWFilter: 'cp312-macosx_x86_64'
 
-    variables:
-      MacOSXDeploymentTarget: '10.9'
-      OpenSSLDir: $(Agent.BuildDirectory)/openssl-macosx$(MacOSXDeploymentTarget)
-      PythonVersion38: '3.8'
-      PythonVersion39: '3.9'
-      PythonVersion310: '3.10'
-      PythonVersion311: '3.11'
-      PythonVersion312: '3.12'
+  #  variables:
+  #    MacOSXDeploymentTarget: '10.9'
+  #    OpenSSLDir: $(Agent.BuildDirectory)/openssl-macosx$(MacOSXDeploymentTarget)
+  #    PythonVersion38: '3.8'
+  #    PythonVersion39: '3.9'
+  #    PythonVersion310: '3.10'
+  #    PythonVersion311: '3.11'
+  #    PythonVersion312: '3.12'
 
-    steps:
-      - task: DownloadPipelineArtifact@1
-        displayName: 'Download OpenSSL artifact'
-        inputs:
-          artifactName: openssl-macosx$(MacOSXDeploymentTarget)
-          buildType: specific
-          buildVersionToDownload: latest
-          downloadPath: $(Agent.BuildDirectory)
-          pipeline: 119 # azure-uamqp-python - openssl
-          project: '29ec6040-b234-4e31-b139-33dc4287b756' # public
+  #  steps:
+  #    - task: DownloadPipelineArtifact@1
+  #      displayName: 'Download OpenSSL artifact'
+  #      inputs:
+  #        artifactName: openssl-macosx$(MacOSXDeploymentTarget)
+  #        buildType: specific
+  #        buildVersionToDownload: latest
+  #        downloadPath: $(Agent.BuildDirectory)
+  #        pipeline: 119 # azure-uamqp-python - openssl
+  #        project: '29ec6040-b234-4e31-b139-33dc4287b756' # public
 
-      - script: sudo xcode-select --switch /Applications/Xcode_13.1.app
-        displayName: 'Select Xcode 13.1'
+  #    - script: sudo xcode-select --switch /Applications/Xcode_13.1.app
+  #      displayName: 'Select Xcode 13.1'
 
-      - template: /.azure-pipelines/use-python-version.yml
-        parameters:
-          versionSpec: '$(PythonVersion)'
+  #    - template: /.azure-pipelines/use-python-version.yml
+  #      parameters:
+  #        versionSpec: '$(PythonVersion)'
 
-      - script: |
-          python -m pip --version
-          python -m pip install --user -r dev_requirements.txt
-        displayName: 'Install dependencies'
-      
-      - bash: |
-          set -o errexit
-          python -m pip install cibuildwheel==2.16.2 --force
-        displayName: Install cibuildwheel 2.16.2
+  #    - script: |
+  #        python -m pip --version
+  #        python -m pip install --user -r dev_requirements.txt
+  #      displayName: 'Install dependencies'
+  #
+  #    - bash: |
+  #        set -o errexit
+  #        python -m pip install cibuildwheel==2.16.2 --force
+  #      displayName: Install cibuildwheel 2.16.2
 
-      - pwsh: |
-          cibuildwheel --output-dir dist .
-        displayName: 'Build uAMQP Wheel'
-        env:
-          CIBW_PRERELEASE_PYTHONS: True
-          CIBW_ARCHS_MACOS: x86_64
-          CIBW_BUILD: $(BWFilter)
-          UAMQP_USE_OPENSSL: true
-          UAMQP_REBUILD_PYX: true
-          UAMQP_SUPPRESS_LINK_FLAGS: true
-          OPENSSL_ROOT_DIR: "/tmp/openssl"
-          OPENSSL_INCLUDE_DIR: "/tmp/openssl/include"
-          LDFLAGS: "-mmacosx-version-min=10.9 -L/tmp/openssl/lib"
-          CFLAGS: "-mmacosx-version-min=10.9 -I/tmp/openssl/include"
+  #    - pwsh: |
+  #        cibuildwheel --output-dir dist .
+  #      displayName: 'Build uAMQP Wheel'
+  #      env:
+  #        CIBW_PRERELEASE_PYTHONS: True
+  #        CIBW_ARCHS_MACOS: x86_64
+  #        CIBW_BUILD: $(BWFilter)
+  #        UAMQP_USE_OPENSSL: true
+  #        UAMQP_REBUILD_PYX: true
+  #        UAMQP_SUPPRESS_LINK_FLAGS: true
+  #        OPENSSL_ROOT_DIR: "/tmp/openssl"
+  #        OPENSSL_INCLUDE_DIR: "/tmp/openssl/include"
+  #        LDFLAGS: "-mmacosx-version-min=10.9 -L/tmp/openssl/lib"
+  #        CFLAGS: "-mmacosx-version-min=10.9 -I/tmp/openssl/include"
 
-      - script: ls ./dist
-        displayName: 'Check output'
+  #    - script: ls ./dist
+  #      displayName: 'Check output'
 
-      - script: |
-          python -m pip install --ignore-installed ./dist/*.whl
-          python -m pip install pytest==6.2.4 --force
-          python -m pip install pytest-asyncio==0.12.0 --force
-          pytest tests --doctest-modules --junitxml=junit/test-results-c.xml
-          pytest samples --doctest-modules --junitxml=junit/test-results-live.xml
-        displayName: 'Run tests'
-        env:
-          EVENT_HUB_HOSTNAME: $(python-eh-livetest-event-hub-hostname)
-          EVENT_HUB_NAME: $(python-eh-livetest-event-hub-name)
-          EVENT_HUB_SAS_POLICY: $(python-eh-livetest-event-hub-sas-policy)
-          EVENT_HUB_SAS_KEY: $(python-eh-livetest-event-hub-sas-key)
-          IOTHUB_HOSTNAME: $(python-iothub-livetest-host-name)
-          IOTHUB_HUB_NAME: $(python-iothub-livetest-hub-name)
-          IOTHUB_DEVICE: $(python-eh-livetest-event-hub-iothub-device)
-          IOTHUB_ENDPOINT: $(python-iothub-livetest-endpoint)
-          IOTHUB_SAS_POLICY: $(python-iothub-livetest-sas-policy)
-          IOTHUB_SAS_KEY: $(python-iothub-livetest-sas-key)
+  #    - script: |
+  #        python -m pip install --ignore-installed ./dist/*.whl
+  #        python -m pip install pytest==6.2.4 --force
+  #        python -m pip install pytest-asyncio==0.12.0 --force
+  #        pytest tests --doctest-modules --junitxml=junit/test-results-c.xml
+  #        pytest samples --doctest-modules --junitxml=junit/test-results-live.xml
+  #      displayName: 'Run tests'
+  #      env:
+  #        EVENT_HUB_HOSTNAME: $(python-eh-livetest-event-hub-hostname)
+  #        EVENT_HUB_NAME: $(python-eh-livetest-event-hub-name)
+  #        EVENT_HUB_SAS_POLICY: $(python-eh-livetest-event-hub-sas-policy)
+  #        EVENT_HUB_SAS_KEY: $(python-eh-livetest-event-hub-sas-key)
+  #        IOTHUB_HOSTNAME: $(python-iothub-livetest-host-name)
+  #        IOTHUB_HUB_NAME: $(python-iothub-livetest-hub-name)
+  #        IOTHUB_DEVICE: $(python-eh-livetest-event-hub-iothub-device)
+  #        IOTHUB_ENDPOINT: $(python-iothub-livetest-endpoint)
+  #        IOTHUB_SAS_POLICY: $(python-iothub-livetest-sas-policy)
+  #        IOTHUB_SAS_KEY: $(python-iothub-livetest-sas-key)
 
-      - task: PublishTestResults@2
-        displayName: 'Publish test results'
-        condition: succeededOrFailed()
-        inputs:
-          testResultsFiles: '**/test-results-*.xml'
-          testResultsFormat: 'JUnit'
-          testRunTitle: 'MacOS Python $(PythonVersion)'
+  #    - task: PublishTestResults@2
+  #      displayName: 'Publish test results'
+  #      condition: succeededOrFailed()
+  #      inputs:
+  #        testResultsFiles: '**/test-results-*.xml'
+  #        testResultsFormat: 'JUnit'
+  #        testRunTitle: 'MacOS Python $(PythonVersion)'
 
-      - task: PublishBuildArtifacts@1
-        displayName: 'Publish wheel artifact'
-        inputs:
-          artifactName: uamqp-macosx$(MacOSXDeploymentTarget)-$(PythonVersion)-whl
-          pathToPublish: 'dist'
+  #    - task: PublishBuildArtifacts@1
+  #      displayName: 'Publish wheel artifact'
+  #      inputs:
+  #        artifactName: uamqp-macosx$(MacOSXDeploymentTarget)-$(PythonVersion)-whl
+  #        pathToPublish: 'dist'
 
-  - job: 'Linux'
+  #- job: 'Linux'
 
-    timeoutInMinutes: 120
+  #  timeoutInMinutes: 120
 
-    dependsOn: 'MacOS'
+  #  dependsOn: 'MacOS'
 
-    pool:
-      vmImage: 'ubuntu-20.04'
+  #  pool:
+  #    vmImage: 'ubuntu-20.04'
 
-    strategy:
-      maxParallel: 1
-      matrix:
-        Python 3.8:
-          PythonVersion: '$(PythonVersion38)'
-          BWFilter: 'cp38-manylinux_x86_64'
-        Python 3.9:
-          PythonVersion: '$(PythonVersion39)'
-          BWFilter: 'cp39-manylinux_x86_64'
-        Python 3.10:
-          PythonVersion: '$(PythonVersion310)'
-          BWFilter: 'cp310-manylinux_x86_64'
-        Python 3.11:
-          PythonVersion: '$(PythonVersion311)'
-          BWFilter: 'cp311-manylinux_x86_64'
-        Python 3.12:
-          PythonVersion: '$(PythonVersion312)'
-          BWFilter: 'cp312-manylinux_x86_64'
+  #  strategy:
+  #    maxParallel: 1
+  #    matrix:
+  #      Python 3.8:
+  #        PythonVersion: '$(PythonVersion38)'
+  #        BWFilter: 'cp38-manylinux_x86_64'
+  #      Python 3.9:
+  #        PythonVersion: '$(PythonVersion39)'
+  #        BWFilter: 'cp39-manylinux_x86_64'
+  #      Python 3.10:
+  #        PythonVersion: '$(PythonVersion310)'
+  #        BWFilter: 'cp310-manylinux_x86_64'
+  #      Python 3.11:
+  #        PythonVersion: '$(PythonVersion311)'
+  #        BWFilter: 'cp311-manylinux_x86_64'
+  #      Python 3.12:
+  #        PythonVersion: '$(PythonVersion312)'
+  #        BWFilter: 'cp312-manylinux_x86_64'
 
-    steps:
-      - template: /.azure-pipelines/use-python-version.yml
-        parameters:
-          versionSpec: '$(PythonVersion)'
+  #  steps:
+  #    - template: /.azure-pipelines/use-python-version.yml
+  #      parameters:
+  #        versionSpec: '$(PythonVersion)'
 
-      - script: |
-          echo "Prepending PATH environment variable with directory: $HOME/.local/bin"
-          echo "##vso[task.prependpath]$HOME/.local/bin"
-        displayName: 'Prepare PATH'
+  #    - script: |
+  #        echo "Prepending PATH environment variable with directory: $HOME/.local/bin"
+  #        echo "##vso[task.prependpath]$HOME/.local/bin"
+  #      displayName: 'Prepare PATH'
 
-      - script: |
-          python --version
-          curl -sS $(GetPip) | python - --user
-          python -m pip --version
-          python -m pip install setuptools --force
-          curl -LO http://archive.ubuntu.com/ubuntu/pool/main/libf/libffi/libffi6_3.2.1-8_amd64.deb && sudo dpkg -i libffi6_3.2.1-8_amd64.deb
-          python -m pip install --user -r dev_requirements.txt
-        displayName: 'Install dependencies'
+  #    - script: |
+  #        python --version
+  #        curl -sS $(GetPip) | python - --user
+  #        python -m pip --version
+  #        python -m pip install setuptools --force
+  #        curl -LO http://archive.ubuntu.com/ubuntu/pool/main/libf/libffi/libffi6_3.2.1-8_amd64.deb && sudo dpkg -i libffi6_3.2.1-8_amd64.deb
+  #        python -m pip install --user -r dev_requirements.txt
+  #      displayName: 'Install dependencies'
 
-      - bash: |
-          set -o errexit
-          python -m pip install cibuildwheel==2.16.2
-        displayName: Install cibuildwheel 2.16.2
+  #    - bash: |
+  #        set -o errexit
+  #        python -m pip install cibuildwheel==2.16.2
+  #      displayName: Install cibuildwheel 2.16.2
 
-      - pwsh: |
-          cibuildwheel --output-dir dist .
-        displayName: 'Build uAMQP Wheel'
-        env:
-          CIBW_BUILD: $(BWFilter)
-          CIBW_PRERELEASE_PYTHONS: True
-          CIBW_BEFORE_BUILD_LINUX: bash utils/install_openssl.sh
-          CIBW_ENVIRONMENT_LINUX: OPENSSL_ROOT_DIR="/opt/pyca/cryptography/openssl" LIBRARY_PATH="/opt/pyca/cryptography/openssl/lib" CPATH="/opt/pyca/cryptography/openssl/include" CIBW_ARCHS_LINUX="x86_64"
+  #    - pwsh: |
+  #        cibuildwheel --output-dir dist .
+  #      displayName: 'Build uAMQP Wheel'
+  #      env:
+  #        CIBW_BUILD: $(BWFilter)
+  #        CIBW_PRERELEASE_PYTHONS: True
+  #        CIBW_BEFORE_BUILD_LINUX: bash utils/install_openssl.sh
+  #        CIBW_ENVIRONMENT_LINUX: OPENSSL_ROOT_DIR="/opt/pyca/cryptography/openssl" LIBRARY_PATH="/opt/pyca/cryptography/openssl/lib" CPATH="/opt/pyca/cryptography/openssl/include" CIBW_ARCHS_LINUX="x86_64"
 
-      - script: ls ./dist
-        displayName: 'Check output'
+  #    - script: ls ./dist
+  #      displayName: 'Check output'
 
-      - script: |
-          python -m pip install --user --ignore-installed ./dist/*.whl
-          python -m pip install --user pytest==6.2.4 --force
-          pytest tests --doctest-modules --junitxml=junit/test-results-c.xml
-          pytest samples --doctest-modules --junitxml=junit/test-results-live.xml
-        displayName: 'Run tests'
-        env:
-          EVENT_HUB_HOSTNAME: $(python-eh-livetest-event-hub-hostname)
-          EVENT_HUB_NAME: $(python-eh-livetest-event-hub-name)
-          EVENT_HUB_SAS_POLICY: $(python-eh-livetest-event-hub-sas-policy)
-          EVENT_HUB_SAS_KEY: $(python-eh-livetest-event-hub-sas-key)
-          IOTHUB_HOSTNAME: $(python-iothub-livetest-host-name)
-          IOTHUB_HUB_NAME: $(python-iothub-livetest-hub-name)
-          IOTHUB_DEVICE: $(python-eh-livetest-event-hub-iothub-device)
-          IOTHUB_ENDPOINT: $(python-iothub-livetest-endpoint)
-          IOTHUB_SAS_POLICY: $(python-iothub-livetest-sas-policy)
-          IOTHUB_SAS_KEY: $(python-iothub-livetest-sas-key)
+  #    - script: |
+  #        python -m pip install --user --ignore-installed ./dist/*.whl
+  #        python -m pip install --user pytest==6.2.4 --force
+  #        pytest tests --doctest-modules --junitxml=junit/test-results-c.xml
+  #        pytest samples --doctest-modules --junitxml=junit/test-results-live.xml
+  #      displayName: 'Run tests'
+  #      env:
+  #        EVENT_HUB_HOSTNAME: $(python-eh-livetest-event-hub-hostname)
+  #        EVENT_HUB_NAME: $(python-eh-livetest-event-hub-name)
+  #        EVENT_HUB_SAS_POLICY: $(python-eh-livetest-event-hub-sas-policy)
+  #        EVENT_HUB_SAS_KEY: $(python-eh-livetest-event-hub-sas-key)
+  #        IOTHUB_HOSTNAME: $(python-iothub-livetest-host-name)
+  #        IOTHUB_HUB_NAME: $(python-iothub-livetest-hub-name)
+  #        IOTHUB_DEVICE: $(python-eh-livetest-event-hub-iothub-device)
+  #        IOTHUB_ENDPOINT: $(python-iothub-livetest-endpoint)
+  #        IOTHUB_SAS_POLICY: $(python-iothub-livetest-sas-policy)
+  #        IOTHUB_SAS_KEY: $(python-iothub-livetest-sas-key)
 
-      - task: PublishTestResults@2
-        displayName: 'Publish test results'
-        condition: succeededOrFailed()
-        inputs:
-          testResultsFiles: '**/test-results-*.xml'
-          testResultsFormat: 'JUnit'
-          testRunTitle: 'Linux Python $(PythonVersion)'
+  #    - task: PublishTestResults@2
+  #      displayName: 'Publish test results'
+  #      condition: succeededOrFailed()
+  #      inputs:
+  #        testResultsFiles: '**/test-results-*.xml'
+  #        testResultsFormat: 'JUnit'
+  #        testRunTitle: 'Linux Python $(PythonVersion)'
 
-      - task: PublishBuildArtifacts@1
-        displayName: 'Publish wheel artifact'
-        inputs:
-          artifactName: uamqp-linux-$(PythonVersion)-whl
-          pathToPublish: 'dist'
+  #    - task: PublishBuildArtifacts@1
+  #      displayName: 'Publish wheel artifact'
+  #      inputs:
+  #        artifactName: uamqp-linux-$(PythonVersion)-whl
+  #        pathToPublish: 'dist'
 
-  - job: 'SDK_LiveTest_windows2019_37'
+  - job: 'SDK_LiveTest_windows2019'
     timeoutInMinutes: 300
     dependsOn: 'Windows'
     pool:
@@ -376,7 +376,7 @@ jobs:
           versionSpec: '$(PythonVersion)'
       - template: /.azure-pipelines/test-eh-sb-sdk.yml
 
-  - job: 'SDK_LiveTest_macOS1015_38'
+  - job: 'SDK_LiveTest_macOS1015'
     timeoutInMinutes: 300
     dependsOn: 'MacOS'
     pool:
@@ -401,7 +401,7 @@ jobs:
           versionSpec: '$(PythonVersion)'
       - template: /.azure-pipelines/test-eh-sb-sdk.yml
 
-  - job: 'SDK_LiveTest_ubuntu1804_39'
+  - job: 'SDK_LiveTest_ubuntu1804'
     timeoutInMinutes: 300
     dependsOn: 'Linux'
     pool:

--- a/.azure-pipelines/client.test.live.yml
+++ b/.azure-pipelines/client.test.live.yml
@@ -346,7 +346,7 @@ jobs:
   #        pathToPublish: 'dist'
 
   - job: 'SDK_LiveTest_windows2019'
-    timeoutInMinutes: 300
+    timeoutInMinutes: 420
     dependsOn: 'Windows'
     pool:
       name: azsdk-pool-mms-win-2022-general

--- a/.azure-pipelines/client.test.live.yml
+++ b/.azure-pipelines/client.test.live.yml
@@ -29,22 +29,22 @@ jobs:
           PythonArchitecture: 'x64'
           PythonVersion: '$(PythonVersion38)'
           BWFilter: 'cp38-win_amd64'
-        #x64 Python 3.9:
-        #  PythonArchitecture: 'x64'
-        #  PythonVersion: '$(PythonVersion39)'
-        #  BWFilter: 'cp39-win_amd64'
-        #x64 Python 3.10:
-        #  PythonArchitecture: 'x64'
-        #  PythonVersion: '$(PythonVersion310)'
-        #  BWFilter: 'cp310-win_amd64'
-        #x64 Python 3.11:
-        #  PythonArchitecture: 'x64'
-        #  PythonVersion: '$(PythonVersion311)'
-        #  BWFilter: 'cp311-win_amd64'
-        #x64 Python 3.12:
-        #  PythonArchitecture: 'x64'
-        #  PythonVersion: '$(PythonVersion312)'
-        #  BWFilter: 'cp312-win_amd64'
+        x64 Python 3.9:
+          PythonArchitecture: 'x64'
+          PythonVersion: '$(PythonVersion39)'
+          BWFilter: 'cp39-win_amd64'
+        x64 Python 3.10:
+          PythonArchitecture: 'x64'
+          PythonVersion: '$(PythonVersion310)'
+          BWFilter: 'cp310-win_amd64'
+        x64 Python 3.11:
+          PythonArchitecture: 'x64'
+          PythonVersion: '$(PythonVersion311)'
+          BWFilter: 'cp311-win_amd64'
+        x64 Python 3.12:
+          PythonArchitecture: 'x64'
+          PythonVersion: '$(PythonVersion312)'
+          BWFilter: 'cp312-win_amd64'
             
     steps:
       - template: /.azure-pipelines/use-python-version.yml
@@ -128,222 +128,222 @@ jobs:
           artifactName: uamqp-win$(PythonArchitecture)-$(PythonVersion)-whl
           pathToPublish: 'dist'
 
-  #- job: 'MacOS'
+  - job: 'MacOS'
 
-  #  timeoutInMinutes: 120
+    timeoutInMinutes: 120
 
-  #  dependsOn: 'Windows'
+    dependsOn: 'Windows'
 
-  #  pool:
-  #    vmImage: 'macos-latest'
+    pool:
+      vmImage: 'macos-latest'
 
-  #  strategy:
-  #    maxParallel: 1
-  #    matrix:
-  #      Python 3.8:
-  #        PythonBin: 'python3'
-  #        PythonVersion: '$(PythonVersion38)'
-  #        BWFilter: 'cp38-macosx_x86_64'
-  #      Python 3.9:
-  #        PythonBin: 'python3'
-  #        PythonVersion: '$(PythonVersion39)'
-  #        BWFilter: 'cp39-macosx_x86_64'
-  #      Python 3.10:
-  #        PythonBin: 'python3'
-  #        PythonVersion: '$(PythonVersion310)'
-  #        BWFilter: 'cp310-macosx_x86_64'
-  #      Python 3.11:
-  #        PythonBin: 'python3'
-  #        PythonVersion: '$(PythonVersion311)'
-  #        BWFilter: 'cp311-macosx_x86_64'
-  #      Python 3.12:
-  #        PythonBin: 'python3'
-  #        PythonVersion: '$(PythonVersion312)'
-  #        BWFilter: 'cp312-macosx_x86_64'
+    strategy:
+      maxParallel: 1
+      matrix:
+        Python 3.8:
+          PythonBin: 'python3'
+          PythonVersion: '$(PythonVersion38)'
+          BWFilter: 'cp38-macosx_x86_64'
+        Python 3.9:
+          PythonBin: 'python3'
+          PythonVersion: '$(PythonVersion39)'
+          BWFilter: 'cp39-macosx_x86_64'
+        Python 3.10:
+          PythonBin: 'python3'
+          PythonVersion: '$(PythonVersion310)'
+          BWFilter: 'cp310-macosx_x86_64'
+        Python 3.11:
+          PythonBin: 'python3'
+          PythonVersion: '$(PythonVersion311)'
+          BWFilter: 'cp311-macosx_x86_64'
+        Python 3.12:
+          PythonBin: 'python3'
+          PythonVersion: '$(PythonVersion312)'
+          BWFilter: 'cp312-macosx_x86_64'
 
-  #  variables:
-  #    MacOSXDeploymentTarget: '10.9'
-  #    OpenSSLDir: $(Agent.BuildDirectory)/openssl-macosx$(MacOSXDeploymentTarget)
-  #    PythonVersion38: '3.8'
-  #    PythonVersion39: '3.9'
-  #    PythonVersion310: '3.10'
-  #    PythonVersion311: '3.11'
-  #    PythonVersion312: '3.12'
+    variables:
+      MacOSXDeploymentTarget: '10.9'
+      OpenSSLDir: $(Agent.BuildDirectory)/openssl-macosx$(MacOSXDeploymentTarget)
+      PythonVersion38: '3.8'
+      PythonVersion39: '3.9'
+      PythonVersion310: '3.10'
+      PythonVersion311: '3.11'
+      PythonVersion312: '3.12'
 
-  #  steps:
-  #    - task: DownloadPipelineArtifact@1
-  #      displayName: 'Download OpenSSL artifact'
-  #      inputs:
-  #        artifactName: openssl-macosx$(MacOSXDeploymentTarget)
-  #        buildType: specific
-  #        buildVersionToDownload: latest
-  #        downloadPath: $(Agent.BuildDirectory)
-  #        pipeline: 119 # azure-uamqp-python - openssl
-  #        project: '29ec6040-b234-4e31-b139-33dc4287b756' # public
+    steps:
+      - task: DownloadPipelineArtifact@1
+        displayName: 'Download OpenSSL artifact'
+        inputs:
+          artifactName: openssl-macosx$(MacOSXDeploymentTarget)
+          buildType: specific
+          buildVersionToDownload: latest
+          downloadPath: $(Agent.BuildDirectory)
+          pipeline: 119 # azure-uamqp-python - openssl
+          project: '29ec6040-b234-4e31-b139-33dc4287b756' # public
 
-  #    - script: sudo xcode-select --switch /Applications/Xcode_13.1.app
-  #      displayName: 'Select Xcode 13.1'
+      - script: sudo xcode-select --switch /Applications/Xcode_13.1.app
+        displayName: 'Select Xcode 13.1'
 
-  #    - template: /.azure-pipelines/use-python-version.yml
-  #      parameters:
-  #        versionSpec: '$(PythonVersion)'
+      - template: /.azure-pipelines/use-python-version.yml
+        parameters:
+          versionSpec: '$(PythonVersion)'
 
-  #    - script: |
-  #        python -m pip --version
-  #        python -m pip install --user -r dev_requirements.txt
-  #      displayName: 'Install dependencies'
-  #
-  #    - bash: |
-  #        set -o errexit
-  #        python -m pip install cibuildwheel==2.16.2 --force
-  #      displayName: Install cibuildwheel 2.16.2
+      - script: |
+          python -m pip --version
+          python -m pip install --user -r dev_requirements.txt
+        displayName: 'Install dependencies'
+  
+      - bash: |
+          set -o errexit
+          python -m pip install cibuildwheel==2.16.2 --force
+        displayName: Install cibuildwheel 2.16.2
 
-  #    - pwsh: |
-  #        cibuildwheel --output-dir dist .
-  #      displayName: 'Build uAMQP Wheel'
-  #      env:
-  #        CIBW_PRERELEASE_PYTHONS: True
-  #        CIBW_ARCHS_MACOS: x86_64
-  #        CIBW_BUILD: $(BWFilter)
-  #        UAMQP_USE_OPENSSL: true
-  #        UAMQP_REBUILD_PYX: true
-  #        UAMQP_SUPPRESS_LINK_FLAGS: true
-  #        OPENSSL_ROOT_DIR: "/tmp/openssl"
-  #        OPENSSL_INCLUDE_DIR: "/tmp/openssl/include"
-  #        LDFLAGS: "-mmacosx-version-min=10.9 -L/tmp/openssl/lib"
-  #        CFLAGS: "-mmacosx-version-min=10.9 -I/tmp/openssl/include"
+      - pwsh: |
+          cibuildwheel --output-dir dist .
+        displayName: 'Build uAMQP Wheel'
+        env:
+          CIBW_PRERELEASE_PYTHONS: True
+          CIBW_ARCHS_MACOS: x86_64
+          CIBW_BUILD: $(BWFilter)
+          UAMQP_USE_OPENSSL: true
+          UAMQP_REBUILD_PYX: true
+          UAMQP_SUPPRESS_LINK_FLAGS: true
+          OPENSSL_ROOT_DIR: "/tmp/openssl"
+          OPENSSL_INCLUDE_DIR: "/tmp/openssl/include"
+          LDFLAGS: "-mmacosx-version-min=10.9 -L/tmp/openssl/lib"
+          CFLAGS: "-mmacosx-version-min=10.9 -I/tmp/openssl/include"
 
-  #    - script: ls ./dist
-  #      displayName: 'Check output'
+      - script: ls ./dist
+        displayName: 'Check output'
 
-  #    - script: |
-  #        python -m pip install --ignore-installed ./dist/*.whl
-  #        python -m pip install pytest==6.2.4 --force
-  #        python -m pip install pytest-asyncio==0.12.0 --force
-  #        pytest tests --doctest-modules --junitxml=junit/test-results-c.xml
-  #        pytest samples --doctest-modules --junitxml=junit/test-results-live.xml
-  #      displayName: 'Run tests'
-  #      env:
-  #        EVENT_HUB_HOSTNAME: $(python-eh-livetest-event-hub-hostname)
-  #        EVENT_HUB_NAME: $(python-eh-livetest-event-hub-name)
-  #        EVENT_HUB_SAS_POLICY: $(python-eh-livetest-event-hub-sas-policy)
-  #        EVENT_HUB_SAS_KEY: $(python-eh-livetest-event-hub-sas-key)
-  #        IOTHUB_HOSTNAME: $(python-iothub-livetest-host-name)
-  #        IOTHUB_HUB_NAME: $(python-iothub-livetest-hub-name)
-  #        IOTHUB_DEVICE: $(python-eh-livetest-event-hub-iothub-device)
-  #        IOTHUB_ENDPOINT: $(python-iothub-livetest-endpoint)
-  #        IOTHUB_SAS_POLICY: $(python-iothub-livetest-sas-policy)
-  #        IOTHUB_SAS_KEY: $(python-iothub-livetest-sas-key)
+      - script: |
+          python -m pip install --ignore-installed ./dist/*.whl
+          python -m pip install pytest==6.2.4 --force
+          python -m pip install pytest-asyncio==0.12.0 --force
+          pytest tests --doctest-modules --junitxml=junit/test-results-c.xml
+          pytest samples --doctest-modules --junitxml=junit/test-results-live.xml
+        displayName: 'Run tests'
+        env:
+          EVENT_HUB_HOSTNAME: $(python-eh-livetest-event-hub-hostname)
+          EVENT_HUB_NAME: $(python-eh-livetest-event-hub-name)
+          EVENT_HUB_SAS_POLICY: $(python-eh-livetest-event-hub-sas-policy)
+          EVENT_HUB_SAS_KEY: $(python-eh-livetest-event-hub-sas-key)
+          IOTHUB_HOSTNAME: $(python-iothub-livetest-host-name)
+          IOTHUB_HUB_NAME: $(python-iothub-livetest-hub-name)
+          IOTHUB_DEVICE: $(python-eh-livetest-event-hub-iothub-device)
+          IOTHUB_ENDPOINT: $(python-iothub-livetest-endpoint)
+          IOTHUB_SAS_POLICY: $(python-iothub-livetest-sas-policy)
+          IOTHUB_SAS_KEY: $(python-iothub-livetest-sas-key)
 
-  #    - task: PublishTestResults@2
-  #      displayName: 'Publish test results'
-  #      condition: succeededOrFailed()
-  #      inputs:
-  #        testResultsFiles: '**/test-results-*.xml'
-  #        testResultsFormat: 'JUnit'
-  #        testRunTitle: 'MacOS Python $(PythonVersion)'
+      - task: PublishTestResults@2
+        displayName: 'Publish test results'
+        condition: succeededOrFailed()
+        inputs:
+          testResultsFiles: '**/test-results-*.xml'
+          testResultsFormat: 'JUnit'
+          testRunTitle: 'MacOS Python $(PythonVersion)'
 
-  #    - task: PublishBuildArtifacts@1
-  #      displayName: 'Publish wheel artifact'
-  #      inputs:
-  #        artifactName: uamqp-macosx$(MacOSXDeploymentTarget)-$(PythonVersion)-whl
-  #        pathToPublish: 'dist'
+      - task: PublishBuildArtifacts@1
+        displayName: 'Publish wheel artifact'
+        inputs:
+          artifactName: uamqp-macosx$(MacOSXDeploymentTarget)-$(PythonVersion)-whl
+          pathToPublish: 'dist'
 
-  #- job: 'Linux'
+  - job: 'Linux'
 
-  #  timeoutInMinutes: 120
+    timeoutInMinutes: 120
 
-  #  dependsOn: 'MacOS'
+    dependsOn: 'MacOS'
 
-  #  pool:
-  #    vmImage: 'ubuntu-20.04'
+    pool:
+      vmImage: 'ubuntu-20.04'
 
-  #  strategy:
-  #    maxParallel: 1
-  #    matrix:
-  #      Python 3.8:
-  #        PythonVersion: '$(PythonVersion38)'
-  #        BWFilter: 'cp38-manylinux_x86_64'
-  #      Python 3.9:
-  #        PythonVersion: '$(PythonVersion39)'
-  #        BWFilter: 'cp39-manylinux_x86_64'
-  #      Python 3.10:
-  #        PythonVersion: '$(PythonVersion310)'
-  #        BWFilter: 'cp310-manylinux_x86_64'
-  #      Python 3.11:
-  #        PythonVersion: '$(PythonVersion311)'
-  #        BWFilter: 'cp311-manylinux_x86_64'
-  #      Python 3.12:
-  #        PythonVersion: '$(PythonVersion312)'
-  #        BWFilter: 'cp312-manylinux_x86_64'
+    strategy:
+      maxParallel: 1
+      matrix:
+        Python 3.8:
+          PythonVersion: '$(PythonVersion38)'
+          BWFilter: 'cp38-manylinux_x86_64'
+        Python 3.9:
+          PythonVersion: '$(PythonVersion39)'
+          BWFilter: 'cp39-manylinux_x86_64'
+        Python 3.10:
+          PythonVersion: '$(PythonVersion310)'
+          BWFilter: 'cp310-manylinux_x86_64'
+        Python 3.11:
+          PythonVersion: '$(PythonVersion311)'
+          BWFilter: 'cp311-manylinux_x86_64'
+        Python 3.12:
+          PythonVersion: '$(PythonVersion312)'
+          BWFilter: 'cp312-manylinux_x86_64'
 
-  #  steps:
-  #    - template: /.azure-pipelines/use-python-version.yml
-  #      parameters:
-  #        versionSpec: '$(PythonVersion)'
+    steps:
+      - template: /.azure-pipelines/use-python-version.yml
+        parameters:
+          versionSpec: '$(PythonVersion)'
 
-  #    - script: |
-  #        echo "Prepending PATH environment variable with directory: $HOME/.local/bin"
-  #        echo "##vso[task.prependpath]$HOME/.local/bin"
-  #      displayName: 'Prepare PATH'
+      - script: |
+          echo "Prepending PATH environment variable with directory: $HOME/.local/bin"
+          echo "##vso[task.prependpath]$HOME/.local/bin"
+        displayName: 'Prepare PATH'
 
-  #    - script: |
-  #        python --version
-  #        curl -sS $(GetPip) | python - --user
-  #        python -m pip --version
-  #        python -m pip install setuptools --force
-  #        curl -LO http://archive.ubuntu.com/ubuntu/pool/main/libf/libffi/libffi6_3.2.1-8_amd64.deb && sudo dpkg -i libffi6_3.2.1-8_amd64.deb
-  #        python -m pip install --user -r dev_requirements.txt
-  #      displayName: 'Install dependencies'
+      - script: |
+          python --version
+          curl -sS $(GetPip) | python - --user
+          python -m pip --version
+          python -m pip install setuptools --force
+          curl -LO http://archive.ubuntu.com/ubuntu/pool/main/libf/libffi/libffi6_3.2.1-8_amd64.deb && sudo dpkg -i libffi6_3.2.1-8_amd64.deb
+          python -m pip install --user -r dev_requirements.txt
+        displayName: 'Install dependencies'
 
-  #    - bash: |
-  #        set -o errexit
-  #        python -m pip install cibuildwheel==2.16.2
-  #      displayName: Install cibuildwheel 2.16.2
+      - bash: |
+          set -o errexit
+          python -m pip install cibuildwheel==2.16.2
+        displayName: Install cibuildwheel 2.16.2
 
-  #    - pwsh: |
-  #        cibuildwheel --output-dir dist .
-  #      displayName: 'Build uAMQP Wheel'
-  #      env:
-  #        CIBW_BUILD: $(BWFilter)
-  #        CIBW_PRERELEASE_PYTHONS: True
-  #        CIBW_BEFORE_BUILD_LINUX: bash utils/install_openssl.sh
-  #        CIBW_ENVIRONMENT_LINUX: OPENSSL_ROOT_DIR="/opt/pyca/cryptography/openssl" LIBRARY_PATH="/opt/pyca/cryptography/openssl/lib" CPATH="/opt/pyca/cryptography/openssl/include" CIBW_ARCHS_LINUX="x86_64"
+      - pwsh: |
+          cibuildwheel --output-dir dist .
+        displayName: 'Build uAMQP Wheel'
+        env:
+          CIBW_BUILD: $(BWFilter)
+          CIBW_PRERELEASE_PYTHONS: True
+          CIBW_BEFORE_BUILD_LINUX: bash utils/install_openssl.sh
+          CIBW_ENVIRONMENT_LINUX: OPENSSL_ROOT_DIR="/opt/pyca/cryptography/openssl" LIBRARY_PATH="/opt/pyca/cryptography/openssl/lib" CPATH="/opt/pyca/cryptography/openssl/include" CIBW_ARCHS_LINUX="x86_64"
 
-  #    - script: ls ./dist
-  #      displayName: 'Check output'
+      - script: ls ./dist
+        displayName: 'Check output'
 
-  #    - script: |
-  #        python -m pip install --user --ignore-installed ./dist/*.whl
-  #        python -m pip install --user pytest==6.2.4 --force
-  #        pytest tests --doctest-modules --junitxml=junit/test-results-c.xml
-  #        pytest samples --doctest-modules --junitxml=junit/test-results-live.xml
-  #      displayName: 'Run tests'
-  #      env:
-  #        EVENT_HUB_HOSTNAME: $(python-eh-livetest-event-hub-hostname)
-  #        EVENT_HUB_NAME: $(python-eh-livetest-event-hub-name)
-  #        EVENT_HUB_SAS_POLICY: $(python-eh-livetest-event-hub-sas-policy)
-  #        EVENT_HUB_SAS_KEY: $(python-eh-livetest-event-hub-sas-key)
-  #        IOTHUB_HOSTNAME: $(python-iothub-livetest-host-name)
-  #        IOTHUB_HUB_NAME: $(python-iothub-livetest-hub-name)
-  #        IOTHUB_DEVICE: $(python-eh-livetest-event-hub-iothub-device)
-  #        IOTHUB_ENDPOINT: $(python-iothub-livetest-endpoint)
-  #        IOTHUB_SAS_POLICY: $(python-iothub-livetest-sas-policy)
-  #        IOTHUB_SAS_KEY: $(python-iothub-livetest-sas-key)
+      - script: |
+          python -m pip install --user --ignore-installed ./dist/*.whl
+          python -m pip install --user pytest==6.2.4 --force
+          pytest tests --doctest-modules --junitxml=junit/test-results-c.xml
+          pytest samples --doctest-modules --junitxml=junit/test-results-live.xml
+        displayName: 'Run tests'
+        env:
+          EVENT_HUB_HOSTNAME: $(python-eh-livetest-event-hub-hostname)
+          EVENT_HUB_NAME: $(python-eh-livetest-event-hub-name)
+          EVENT_HUB_SAS_POLICY: $(python-eh-livetest-event-hub-sas-policy)
+          EVENT_HUB_SAS_KEY: $(python-eh-livetest-event-hub-sas-key)
+          IOTHUB_HOSTNAME: $(python-iothub-livetest-host-name)
+          IOTHUB_HUB_NAME: $(python-iothub-livetest-hub-name)
+          IOTHUB_DEVICE: $(python-eh-livetest-event-hub-iothub-device)
+          IOTHUB_ENDPOINT: $(python-iothub-livetest-endpoint)
+          IOTHUB_SAS_POLICY: $(python-iothub-livetest-sas-policy)
+          IOTHUB_SAS_KEY: $(python-iothub-livetest-sas-key)
 
-  #    - task: PublishTestResults@2
-  #      displayName: 'Publish test results'
-  #      condition: succeededOrFailed()
-  #      inputs:
-  #        testResultsFiles: '**/test-results-*.xml'
-  #        testResultsFormat: 'JUnit'
-  #        testRunTitle: 'Linux Python $(PythonVersion)'
+      - task: PublishTestResults@2
+        displayName: 'Publish test results'
+        condition: succeededOrFailed()
+        inputs:
+          testResultsFiles: '**/test-results-*.xml'
+          testResultsFormat: 'JUnit'
+          testRunTitle: 'Linux Python $(PythonVersion)'
 
-  #    - task: PublishBuildArtifacts@1
-  #      displayName: 'Publish wheel artifact'
-  #      inputs:
-  #        artifactName: uamqp-linux-$(PythonVersion)-whl
-  #        pathToPublish: 'dist'
+      - task: PublishBuildArtifacts@1
+        displayName: 'Publish wheel artifact'
+        inputs:
+          artifactName: uamqp-linux-$(PythonVersion)-whl
+          pathToPublish: 'dist'
 
   - job: 'SDK_LiveTest_windows2019'
     timeoutInMinutes: 300
@@ -356,15 +356,15 @@ jobs:
         EventHub x64 Python 3.8:
           PythonVersion: '$(PythonVersion38)'
           SDK: 'EventHub'
-        #EventHub x64 Python 3.12:
-        #  PythonVersion: '$(PythonVersion312)'
-        #  SDK: 'EventHub'
+        EventHub x64 Python 3.12:
+          PythonVersion: '$(PythonVersion312)'
+          SDK: 'EventHub'
         ServiceBus x64 Python 3.8:
           PythonVersion: '$(PythonVersion38)'
           SDK: 'ServiceBus'
-        #ServiceBus x64 Python 3.12:
-        #  PythonVersion: '$(PythonVersion312)'
-        #  SDK: 'ServiceBus'
+        ServiceBus x64 Python 3.12:
+          PythonVersion: '$(PythonVersion312)'
+          SDK: 'ServiceBus'
     variables:
       PythonArchitecture: 'x64'
       OSArch: 'Windows'
@@ -376,56 +376,56 @@ jobs:
           versionSpec: '$(PythonVersion)'
       - template: /.azure-pipelines/test-eh-sb-sdk.yml
 
-  #- job: 'SDK_LiveTest_macOS1015'
-  #  timeoutInMinutes: 300
-  #  dependsOn: 'MacOS'
-  #  pool:
-  #    name: 'Azure Pipelines'
-  #    vmImage: 'macOS-11'
-  #  strategy:
-  #    matrix:
-  #      EventHub Python 3.12:
-  #        SDK: 'EventHub'
-  #      ServiceBus Python 3.12:
-  #        SDK: 'ServiceBus'
-  #  variables:
-  #    PythonBin: 'python3'
-  #    PythonVersion: '3.12.0'
-  #    MacOSXDeploymentTarget: '10.9'
-  #    PythonVersion382: '3.12'
-  #    OSArch: 'MacOS'
-  #    DownloadArtifactFolder: 'uamqp-macosx$(MacOSXDeploymentTarget)-$(PythonVersion)-whl'
-  #  steps:
-  #    - template: /.azure-pipelines/use-python-version.yml
-  #      parameters:
-  #        versionSpec: '$(PythonVersion)'
-  #    - template: /.azure-pipelines/test-eh-sb-sdk.yml
+  - job: 'SDK_LiveTest_macOS1015'
+    timeoutInMinutes: 300
+    dependsOn: 'MacOS'
+    pool:
+      name: 'Azure Pipelines'
+      vmImage: 'macOS-11'
+    strategy:
+      matrix:
+        EventHub Python 3.12:
+          SDK: 'EventHub'
+        ServiceBus Python 3.12:
+          SDK: 'ServiceBus'
+    variables:
+      PythonBin: 'python3'
+      PythonVersion: '3.12.0'
+      MacOSXDeploymentTarget: '10.9'
+      PythonVersion382: '3.12'
+      OSArch: 'MacOS'
+      DownloadArtifactFolder: 'uamqp-macosx$(MacOSXDeploymentTarget)-$(PythonVersion)-whl'
+    steps:
+      - template: /.azure-pipelines/use-python-version.yml
+        parameters:
+          versionSpec: '$(PythonVersion)'
+      - template: /.azure-pipelines/test-eh-sb-sdk.yml
 
-  #- job: 'SDK_LiveTest_ubuntu1804'
-  #  timeoutInMinutes: 300
-  #  dependsOn: 'Linux'
-  #  pool:
-  #    name: 'azsdk-pool-mms-ubuntu-2004-general'
-  #    vmImage: 'ubuntu-20.04'
-  #  strategy:
-  #    matrix:
-  #      EventHub Python 3.9:
-  #        PythonVersion: '$(PythonVersion39)'
-  #        SDK: 'EventHub'
-  #      EventHub Python 3.12:
-  #        PythonVersion: '$(PythonVersion312)'
-  #        SDK: 'EventHub'
-  #      ServiceBus Python 3.9:
-  #        PythonVersion: '$(PythonVersion39)'
-  #        SDK: 'ServiceBus'
-  #      ServiceBus Python 3.12:
-  #        PythonVersion: '$(PythonVersion312)'
-  #        SDK: 'ServiceBus'
-  #  variables:
-  #    OSArch: 'Linux'
-  #    DownloadArtifactFolder: 'uamqp-linux-$(PythonVersion)-whl'
-  #  steps:
-  #    - template: /.azure-pipelines/use-python-version.yml
-  #      parameters:
-  #        versionSpec: '$(PythonVersion)'
-  #    - template: /.azure-pipelines/test-eh-sb-sdk.yml
+  - job: 'SDK_LiveTest_ubuntu1804'
+    timeoutInMinutes: 300
+    dependsOn: 'Linux'
+    pool:
+      name: 'azsdk-pool-mms-ubuntu-2004-general'
+      vmImage: 'ubuntu-20.04'
+    strategy:
+      matrix:
+        EventHub Python 3.9:
+          PythonVersion: '$(PythonVersion39)'
+          SDK: 'EventHub'
+        EventHub Python 3.12:
+          PythonVersion: '$(PythonVersion312)'
+          SDK: 'EventHub'
+        ServiceBus Python 3.9:
+          PythonVersion: '$(PythonVersion39)'
+          SDK: 'ServiceBus'
+        ServiceBus Python 3.12:
+          PythonVersion: '$(PythonVersion312)'
+          SDK: 'ServiceBus'
+    variables:
+      OSArch: 'Linux'
+      DownloadArtifactFolder: 'uamqp-linux-$(PythonVersion)-whl'
+    steps:
+      - template: /.azure-pipelines/use-python-version.yml
+        parameters:
+          versionSpec: '$(PythonVersion)'
+      - template: /.azure-pipelines/test-eh-sb-sdk.yml

--- a/.azure-pipelines/client.test.live.yml
+++ b/.azure-pipelines/client.test.live.yml
@@ -29,22 +29,22 @@ jobs:
           PythonArchitecture: 'x64'
           PythonVersion: '$(PythonVersion38)'
           BWFilter: 'cp38-win_amd64'
-        x64 Python 3.9:
-          PythonArchitecture: 'x64'
-          PythonVersion: '$(PythonVersion39)'
-          BWFilter: 'cp39-win_amd64'
-        x64 Python 3.10:
-          PythonArchitecture: 'x64'
-          PythonVersion: '$(PythonVersion310)'
-          BWFilter: 'cp310-win_amd64'
-        x64 Python 3.11:
-          PythonArchitecture: 'x64'
-          PythonVersion: '$(PythonVersion311)'
-          BWFilter: 'cp311-win_amd64'
-        x64 Python 3.12:
-          PythonArchitecture: 'x64'
-          PythonVersion: '$(PythonVersion312)'
-          BWFilter: 'cp312-win_amd64'
+        #x64 Python 3.9:
+        #  PythonArchitecture: 'x64'
+        #  PythonVersion: '$(PythonVersion39)'
+        #  BWFilter: 'cp39-win_amd64'
+        #x64 Python 3.10:
+        #  PythonArchitecture: 'x64'
+        #  PythonVersion: '$(PythonVersion310)'
+        #  BWFilter: 'cp310-win_amd64'
+        #x64 Python 3.11:
+        #  PythonArchitecture: 'x64'
+        #  PythonVersion: '$(PythonVersion311)'
+        #  BWFilter: 'cp311-win_amd64'
+        #x64 Python 3.12:
+        #  PythonArchitecture: 'x64'
+        #  PythonVersion: '$(PythonVersion312)'
+        #  BWFilter: 'cp312-win_amd64'
             
     steps:
       - template: /.azure-pipelines/use-python-version.yml
@@ -128,222 +128,222 @@ jobs:
           artifactName: uamqp-win$(PythonArchitecture)-$(PythonVersion)-whl
           pathToPublish: 'dist'
 
-  - job: 'MacOS'
+  #- job: 'MacOS'
 
-    timeoutInMinutes: 120
+  #  timeoutInMinutes: 120
 
-    dependsOn: 'Windows'
+  #  dependsOn: 'Windows'
 
-    pool:
-      vmImage: 'macos-latest'
+  #  pool:
+  #    vmImage: 'macos-latest'
 
-    strategy:
-      maxParallel: 1
-      matrix:
-        Python 3.8:
-          PythonBin: 'python3'
-          PythonVersion: '$(PythonVersion38)'
-          BWFilter: 'cp38-macosx_x86_64'
-        Python 3.9:
-          PythonBin: 'python3'
-          PythonVersion: '$(PythonVersion39)'
-          BWFilter: 'cp39-macosx_x86_64'
-        Python 3.10:
-          PythonBin: 'python3'
-          PythonVersion: '$(PythonVersion310)'
-          BWFilter: 'cp310-macosx_x86_64'
-        Python 3.11:
-          PythonBin: 'python3'
-          PythonVersion: '$(PythonVersion311)'
-          BWFilter: 'cp311-macosx_x86_64'
-        Python 3.12:
-          PythonBin: 'python3'
-          PythonVersion: '$(PythonVersion312)'
-          BWFilter: 'cp312-macosx_x86_64'
+  #  strategy:
+  #    maxParallel: 1
+  #    matrix:
+  #      Python 3.8:
+  #        PythonBin: 'python3'
+  #        PythonVersion: '$(PythonVersion38)'
+  #        BWFilter: 'cp38-macosx_x86_64'
+  #      Python 3.9:
+  #        PythonBin: 'python3'
+  #        PythonVersion: '$(PythonVersion39)'
+  #        BWFilter: 'cp39-macosx_x86_64'
+  #      Python 3.10:
+  #        PythonBin: 'python3'
+  #        PythonVersion: '$(PythonVersion310)'
+  #        BWFilter: 'cp310-macosx_x86_64'
+  #      Python 3.11:
+  #        PythonBin: 'python3'
+  #        PythonVersion: '$(PythonVersion311)'
+  #        BWFilter: 'cp311-macosx_x86_64'
+  #      Python 3.12:
+  #        PythonBin: 'python3'
+  #        PythonVersion: '$(PythonVersion312)'
+  #        BWFilter: 'cp312-macosx_x86_64'
 
-    variables:
-      MacOSXDeploymentTarget: '10.9'
-      OpenSSLDir: $(Agent.BuildDirectory)/openssl-macosx$(MacOSXDeploymentTarget)
-      PythonVersion38: '3.8'
-      PythonVersion39: '3.9'
-      PythonVersion310: '3.10'
-      PythonVersion311: '3.11'
-      PythonVersion312: '3.12'
+  #  variables:
+  #    MacOSXDeploymentTarget: '10.9'
+  #    OpenSSLDir: $(Agent.BuildDirectory)/openssl-macosx$(MacOSXDeploymentTarget)
+  #    PythonVersion38: '3.8'
+  #    PythonVersion39: '3.9'
+  #    PythonVersion310: '3.10'
+  #    PythonVersion311: '3.11'
+  #    PythonVersion312: '3.12'
 
-    steps:
-      - task: DownloadPipelineArtifact@1
-        displayName: 'Download OpenSSL artifact'
-        inputs:
-          artifactName: openssl-macosx$(MacOSXDeploymentTarget)
-          buildType: specific
-          buildVersionToDownload: latest
-          downloadPath: $(Agent.BuildDirectory)
-          pipeline: 119 # azure-uamqp-python - openssl
-          project: '29ec6040-b234-4e31-b139-33dc4287b756' # public
+  #  steps:
+  #    - task: DownloadPipelineArtifact@1
+  #      displayName: 'Download OpenSSL artifact'
+  #      inputs:
+  #        artifactName: openssl-macosx$(MacOSXDeploymentTarget)
+  #        buildType: specific
+  #        buildVersionToDownload: latest
+  #        downloadPath: $(Agent.BuildDirectory)
+  #        pipeline: 119 # azure-uamqp-python - openssl
+  #        project: '29ec6040-b234-4e31-b139-33dc4287b756' # public
 
-      - script: sudo xcode-select --switch /Applications/Xcode_13.1.app
-        displayName: 'Select Xcode 13.1'
+  #    - script: sudo xcode-select --switch /Applications/Xcode_13.1.app
+  #      displayName: 'Select Xcode 13.1'
 
-      - template: /.azure-pipelines/use-python-version.yml
-        parameters:
-          versionSpec: '$(PythonVersion)'
+  #    - template: /.azure-pipelines/use-python-version.yml
+  #      parameters:
+  #        versionSpec: '$(PythonVersion)'
 
-      - script: |
-          python -m pip --version
-          python -m pip install --user -r dev_requirements.txt
-        displayName: 'Install dependencies'
+  #    - script: |
+  #        python -m pip --version
+  #        python -m pip install --user -r dev_requirements.txt
+  #      displayName: 'Install dependencies'
   
-      - bash: |
-          set -o errexit
-          python -m pip install cibuildwheel==2.16.2 --force
-        displayName: Install cibuildwheel 2.16.2
+  #    - bash: |
+  #        set -o errexit
+  #        python -m pip install cibuildwheel==2.16.2 --force
+  #      displayName: Install cibuildwheel 2.16.2
 
-      - pwsh: |
-          cibuildwheel --output-dir dist .
-        displayName: 'Build uAMQP Wheel'
-        env:
-          CIBW_PRERELEASE_PYTHONS: True
-          CIBW_ARCHS_MACOS: x86_64
-          CIBW_BUILD: $(BWFilter)
-          UAMQP_USE_OPENSSL: true
-          UAMQP_REBUILD_PYX: true
-          UAMQP_SUPPRESS_LINK_FLAGS: true
-          OPENSSL_ROOT_DIR: "/tmp/openssl"
-          OPENSSL_INCLUDE_DIR: "/tmp/openssl/include"
-          LDFLAGS: "-mmacosx-version-min=10.9 -L/tmp/openssl/lib"
-          CFLAGS: "-mmacosx-version-min=10.9 -I/tmp/openssl/include"
+  #    - pwsh: |
+  #        cibuildwheel --output-dir dist .
+  #      displayName: 'Build uAMQP Wheel'
+  #      env:
+  #        CIBW_PRERELEASE_PYTHONS: True
+  #        CIBW_ARCHS_MACOS: x86_64
+  #        CIBW_BUILD: $(BWFilter)
+  #        UAMQP_USE_OPENSSL: true
+  #        UAMQP_REBUILD_PYX: true
+  #        UAMQP_SUPPRESS_LINK_FLAGS: true
+  #        OPENSSL_ROOT_DIR: "/tmp/openssl"
+  #        OPENSSL_INCLUDE_DIR: "/tmp/openssl/include"
+  #        LDFLAGS: "-mmacosx-version-min=10.9 -L/tmp/openssl/lib"
+  #        CFLAGS: "-mmacosx-version-min=10.9 -I/tmp/openssl/include"
 
-      - script: ls ./dist
-        displayName: 'Check output'
+  #    - script: ls ./dist
+  #      displayName: 'Check output'
 
-      - script: |
-          python -m pip install --ignore-installed ./dist/*.whl
-          python -m pip install pytest==6.2.4 --force
-          python -m pip install pytest-asyncio==0.12.0 --force
-          pytest tests --doctest-modules --junitxml=junit/test-results-c.xml
-          pytest samples --doctest-modules --junitxml=junit/test-results-live.xml
-        displayName: 'Run tests'
-        env:
-          EVENT_HUB_HOSTNAME: $(python-eh-livetest-event-hub-hostname)
-          EVENT_HUB_NAME: $(python-eh-livetest-event-hub-name)
-          EVENT_HUB_SAS_POLICY: $(python-eh-livetest-event-hub-sas-policy)
-          EVENT_HUB_SAS_KEY: $(python-eh-livetest-event-hub-sas-key)
-          IOTHUB_HOSTNAME: $(python-iothub-livetest-host-name)
-          IOTHUB_HUB_NAME: $(python-iothub-livetest-hub-name)
-          IOTHUB_DEVICE: $(python-eh-livetest-event-hub-iothub-device)
-          IOTHUB_ENDPOINT: $(python-iothub-livetest-endpoint)
-          IOTHUB_SAS_POLICY: $(python-iothub-livetest-sas-policy)
-          IOTHUB_SAS_KEY: $(python-iothub-livetest-sas-key)
+  #    - script: |
+  #        python -m pip install --ignore-installed ./dist/*.whl
+  #        python -m pip install pytest==6.2.4 --force
+  #        python -m pip install pytest-asyncio==0.12.0 --force
+  #        pytest tests --doctest-modules --junitxml=junit/test-results-c.xml
+  #        pytest samples --doctest-modules --junitxml=junit/test-results-live.xml
+  #      displayName: 'Run tests'
+  #      env:
+  #        EVENT_HUB_HOSTNAME: $(python-eh-livetest-event-hub-hostname)
+  #        EVENT_HUB_NAME: $(python-eh-livetest-event-hub-name)
+  #        EVENT_HUB_SAS_POLICY: $(python-eh-livetest-event-hub-sas-policy)
+  #        EVENT_HUB_SAS_KEY: $(python-eh-livetest-event-hub-sas-key)
+  #        IOTHUB_HOSTNAME: $(python-iothub-livetest-host-name)
+  #        IOTHUB_HUB_NAME: $(python-iothub-livetest-hub-name)
+  #        IOTHUB_DEVICE: $(python-eh-livetest-event-hub-iothub-device)
+  #        IOTHUB_ENDPOINT: $(python-iothub-livetest-endpoint)
+  #        IOTHUB_SAS_POLICY: $(python-iothub-livetest-sas-policy)
+  #        IOTHUB_SAS_KEY: $(python-iothub-livetest-sas-key)
 
-      - task: PublishTestResults@2
-        displayName: 'Publish test results'
-        condition: succeededOrFailed()
-        inputs:
-          testResultsFiles: '**/test-results-*.xml'
-          testResultsFormat: 'JUnit'
-          testRunTitle: 'MacOS Python $(PythonVersion)'
+  #    - task: PublishTestResults@2
+  #      displayName: 'Publish test results'
+  #      condition: succeededOrFailed()
+  #      inputs:
+  #        testResultsFiles: '**/test-results-*.xml'
+  #        testResultsFormat: 'JUnit'
+  #        testRunTitle: 'MacOS Python $(PythonVersion)'
 
-      - task: PublishBuildArtifacts@1
-        displayName: 'Publish wheel artifact'
-        inputs:
-          artifactName: uamqp-macosx$(MacOSXDeploymentTarget)-$(PythonVersion)-whl
-          pathToPublish: 'dist'
+  #    - task: PublishBuildArtifacts@1
+  #      displayName: 'Publish wheel artifact'
+  #      inputs:
+  #        artifactName: uamqp-macosx$(MacOSXDeploymentTarget)-$(PythonVersion)-whl
+  #        pathToPublish: 'dist'
 
-  - job: 'Linux'
+  #- job: 'Linux'
 
-    timeoutInMinutes: 120
+  #  timeoutInMinutes: 120
 
-    dependsOn: 'MacOS'
+  #  dependsOn: 'MacOS'
 
-    pool:
-      vmImage: 'ubuntu-20.04'
+  #  pool:
+  #    vmImage: 'ubuntu-20.04'
 
-    strategy:
-      maxParallel: 1
-      matrix:
-        Python 3.8:
-          PythonVersion: '$(PythonVersion38)'
-          BWFilter: 'cp38-manylinux_x86_64'
-        Python 3.9:
-          PythonVersion: '$(PythonVersion39)'
-          BWFilter: 'cp39-manylinux_x86_64'
-        Python 3.10:
-          PythonVersion: '$(PythonVersion310)'
-          BWFilter: 'cp310-manylinux_x86_64'
-        Python 3.11:
-          PythonVersion: '$(PythonVersion311)'
-          BWFilter: 'cp311-manylinux_x86_64'
-        Python 3.12:
-          PythonVersion: '$(PythonVersion312)'
-          BWFilter: 'cp312-manylinux_x86_64'
+  #  strategy:
+  #    maxParallel: 1
+  #    matrix:
+  #      Python 3.8:
+  #        PythonVersion: '$(PythonVersion38)'
+  #        BWFilter: 'cp38-manylinux_x86_64'
+  #      Python 3.9:
+  #        PythonVersion: '$(PythonVersion39)'
+  #        BWFilter: 'cp39-manylinux_x86_64'
+  #      Python 3.10:
+  #        PythonVersion: '$(PythonVersion310)'
+  #        BWFilter: 'cp310-manylinux_x86_64'
+  #      Python 3.11:
+  #        PythonVersion: '$(PythonVersion311)'
+  #        BWFilter: 'cp311-manylinux_x86_64'
+  #      Python 3.12:
+  #        PythonVersion: '$(PythonVersion312)'
+  #        BWFilter: 'cp312-manylinux_x86_64'
 
-    steps:
-      - template: /.azure-pipelines/use-python-version.yml
-        parameters:
-          versionSpec: '$(PythonVersion)'
+  #  steps:
+  #    - template: /.azure-pipelines/use-python-version.yml
+  #      parameters:
+  #        versionSpec: '$(PythonVersion)'
 
-      - script: |
-          echo "Prepending PATH environment variable with directory: $HOME/.local/bin"
-          echo "##vso[task.prependpath]$HOME/.local/bin"
-        displayName: 'Prepare PATH'
+  #    - script: |
+  #        echo "Prepending PATH environment variable with directory: $HOME/.local/bin"
+  #        echo "##vso[task.prependpath]$HOME/.local/bin"
+  #      displayName: 'Prepare PATH'
 
-      - script: |
-          python --version
-          curl -sS $(GetPip) | python - --user
-          python -m pip --version
-          python -m pip install setuptools --force
-          curl -LO http://archive.ubuntu.com/ubuntu/pool/main/libf/libffi/libffi6_3.2.1-8_amd64.deb && sudo dpkg -i libffi6_3.2.1-8_amd64.deb
-          python -m pip install --user -r dev_requirements.txt
-        displayName: 'Install dependencies'
+  #    - script: |
+  #        python --version
+  #        curl -sS $(GetPip) | python - --user
+  #        python -m pip --version
+  #        python -m pip install setuptools --force
+  #        curl -LO http://archive.ubuntu.com/ubuntu/pool/main/libf/libffi/libffi6_3.2.1-8_amd64.deb && sudo dpkg -i libffi6_3.2.1-8_amd64.deb
+  #        python -m pip install --user -r dev_requirements.txt
+  #      displayName: 'Install dependencies'
 
-      - bash: |
-          set -o errexit
-          python -m pip install cibuildwheel==2.16.2
-        displayName: Install cibuildwheel 2.16.2
+  #    - bash: |
+  #        set -o errexit
+  #        python -m pip install cibuildwheel==2.16.2
+  #      displayName: Install cibuildwheel 2.16.2
 
-      - pwsh: |
-          cibuildwheel --output-dir dist .
-        displayName: 'Build uAMQP Wheel'
-        env:
-          CIBW_BUILD: $(BWFilter)
-          CIBW_PRERELEASE_PYTHONS: True
-          CIBW_BEFORE_BUILD_LINUX: bash utils/install_openssl.sh
-          CIBW_ENVIRONMENT_LINUX: OPENSSL_ROOT_DIR="/opt/pyca/cryptography/openssl" LIBRARY_PATH="/opt/pyca/cryptography/openssl/lib" CPATH="/opt/pyca/cryptography/openssl/include" CIBW_ARCHS_LINUX="x86_64"
+  #    - pwsh: |
+  #        cibuildwheel --output-dir dist .
+  #      displayName: 'Build uAMQP Wheel'
+  #      env:
+  #        CIBW_BUILD: $(BWFilter)
+  #        CIBW_PRERELEASE_PYTHONS: True
+  #        CIBW_BEFORE_BUILD_LINUX: bash utils/install_openssl.sh
+  #        CIBW_ENVIRONMENT_LINUX: OPENSSL_ROOT_DIR="/opt/pyca/cryptography/openssl" LIBRARY_PATH="/opt/pyca/cryptography/openssl/lib" CPATH="/opt/pyca/cryptography/openssl/include" CIBW_ARCHS_LINUX="x86_64"
 
-      - script: ls ./dist
-        displayName: 'Check output'
+  #    - script: ls ./dist
+  #      displayName: 'Check output'
 
-      - script: |
-          python -m pip install --user --ignore-installed ./dist/*.whl
-          python -m pip install --user pytest==6.2.4 --force
-          pytest tests --doctest-modules --junitxml=junit/test-results-c.xml
-          pytest samples --doctest-modules --junitxml=junit/test-results-live.xml
-        displayName: 'Run tests'
-        env:
-          EVENT_HUB_HOSTNAME: $(python-eh-livetest-event-hub-hostname)
-          EVENT_HUB_NAME: $(python-eh-livetest-event-hub-name)
-          EVENT_HUB_SAS_POLICY: $(python-eh-livetest-event-hub-sas-policy)
-          EVENT_HUB_SAS_KEY: $(python-eh-livetest-event-hub-sas-key)
-          IOTHUB_HOSTNAME: $(python-iothub-livetest-host-name)
-          IOTHUB_HUB_NAME: $(python-iothub-livetest-hub-name)
-          IOTHUB_DEVICE: $(python-eh-livetest-event-hub-iothub-device)
-          IOTHUB_ENDPOINT: $(python-iothub-livetest-endpoint)
-          IOTHUB_SAS_POLICY: $(python-iothub-livetest-sas-policy)
-          IOTHUB_SAS_KEY: $(python-iothub-livetest-sas-key)
+  #    - script: |
+  #        python -m pip install --user --ignore-installed ./dist/*.whl
+  #        python -m pip install --user pytest==6.2.4 --force
+  #        pytest tests --doctest-modules --junitxml=junit/test-results-c.xml
+  #        pytest samples --doctest-modules --junitxml=junit/test-results-live.xml
+  #      displayName: 'Run tests'
+  #      env:
+  #        EVENT_HUB_HOSTNAME: $(python-eh-livetest-event-hub-hostname)
+  #        EVENT_HUB_NAME: $(python-eh-livetest-event-hub-name)
+  #        EVENT_HUB_SAS_POLICY: $(python-eh-livetest-event-hub-sas-policy)
+  #        EVENT_HUB_SAS_KEY: $(python-eh-livetest-event-hub-sas-key)
+  #        IOTHUB_HOSTNAME: $(python-iothub-livetest-host-name)
+  #        IOTHUB_HUB_NAME: $(python-iothub-livetest-hub-name)
+  #        IOTHUB_DEVICE: $(python-eh-livetest-event-hub-iothub-device)
+  #        IOTHUB_ENDPOINT: $(python-iothub-livetest-endpoint)
+  #        IOTHUB_SAS_POLICY: $(python-iothub-livetest-sas-policy)
+  #        IOTHUB_SAS_KEY: $(python-iothub-livetest-sas-key)
 
-      - task: PublishTestResults@2
-        displayName: 'Publish test results'
-        condition: succeededOrFailed()
-        inputs:
-          testResultsFiles: '**/test-results-*.xml'
-          testResultsFormat: 'JUnit'
-          testRunTitle: 'Linux Python $(PythonVersion)'
+  #    - task: PublishTestResults@2
+  #      displayName: 'Publish test results'
+  #      condition: succeededOrFailed()
+  #      inputs:
+  #        testResultsFiles: '**/test-results-*.xml'
+  #        testResultsFormat: 'JUnit'
+  #        testRunTitle: 'Linux Python $(PythonVersion)'
 
-      - task: PublishBuildArtifacts@1
-        displayName: 'Publish wheel artifact'
-        inputs:
-          artifactName: uamqp-linux-$(PythonVersion)-whl
-          pathToPublish: 'dist'
+  #    - task: PublishBuildArtifacts@1
+  #      displayName: 'Publish wheel artifact'
+  #      inputs:
+  #        artifactName: uamqp-linux-$(PythonVersion)-whl
+  #        pathToPublish: 'dist'
 
   - job: 'SDK_LiveTest_windows2019'
     timeoutInMinutes: 300
@@ -353,18 +353,18 @@ jobs:
       vmImage: windows-2022
     strategy:
       matrix:
-        EventHub x64 Python 3.8:
-          PythonVersion: '$(PythonVersion38)'
-          SDK: 'EventHub'
-        EventHub x64 Python 3.12:
-          PythonVersion: '$(PythonVersion312)'
-          SDK: 'EventHub'
+        #EventHub x64 Python 3.8:
+        #  PythonVersion: '$(PythonVersion38)'
+        #  SDK: 'EventHub'
+        #EventHub x64 Python 3.12:
+        #  PythonVersion: '$(PythonVersion312)'
+        #  SDK: 'EventHub'
         ServiceBus x64 Python 3.8:
           PythonVersion: '$(PythonVersion38)'
           SDK: 'ServiceBus'
-        ServiceBus x64 Python 3.12:
-          PythonVersion: '$(PythonVersion312)'
-          SDK: 'ServiceBus'
+        #ServiceBus x64 Python 3.12:
+        #  PythonVersion: '$(PythonVersion312)'
+        #  SDK: 'ServiceBus'
     variables:
       PythonArchitecture: 'x64'
       OSArch: 'Windows'
@@ -376,56 +376,56 @@ jobs:
           versionSpec: '$(PythonVersion)'
       - template: /.azure-pipelines/test-eh-sb-sdk.yml
 
-  - job: 'SDK_LiveTest_macOS1015'
-    timeoutInMinutes: 300
-    dependsOn: 'MacOS'
-    pool:
-      name: 'Azure Pipelines'
-      vmImage: 'macOS-11'
-    strategy:
-      matrix:
-        EventHub Python 3.12:
-          SDK: 'EventHub'
-        ServiceBus Python 3.12:
-          SDK: 'ServiceBus'
-    variables:
-      PythonBin: 'python3'
-      PythonVersion: '3.12.0'
-      MacOSXDeploymentTarget: '10.9'
-      PythonVersion382: '3.12'
-      OSArch: 'MacOS'
-      DownloadArtifactFolder: 'uamqp-macosx$(MacOSXDeploymentTarget)-$(PythonVersion)-whl'
-    steps:
-      - template: /.azure-pipelines/use-python-version.yml
-        parameters:
-          versionSpec: '$(PythonVersion)'
-      - template: /.azure-pipelines/test-eh-sb-sdk.yml
+  #- job: 'SDK_LiveTest_macOS1015'
+  #  timeoutInMinutes: 300
+  #  dependsOn: 'MacOS'
+  #  pool:
+  #    name: 'Azure Pipelines'
+  #    vmImage: 'macOS-11'
+  #  strategy:
+  #    matrix:
+  #      EventHub Python 3.12:
+  #        SDK: 'EventHub'
+  #      ServiceBus Python 3.12:
+  #        SDK: 'ServiceBus'
+  #  variables:
+  #    PythonBin: 'python3'
+  #    PythonVersion: '3.12.0'
+  #    MacOSXDeploymentTarget: '10.9'
+  #    PythonVersion382: '3.12'
+  #    OSArch: 'MacOS'
+  #    DownloadArtifactFolder: 'uamqp-macosx$(MacOSXDeploymentTarget)-$(PythonVersion)-whl'
+  #  steps:
+  #    - template: /.azure-pipelines/use-python-version.yml
+  #      parameters:
+  #        versionSpec: '$(PythonVersion)'
+  #    - template: /.azure-pipelines/test-eh-sb-sdk.yml
 
-  - job: 'SDK_LiveTest_ubuntu1804'
-    timeoutInMinutes: 300
-    dependsOn: 'Linux'
-    pool:
-      name: 'azsdk-pool-mms-ubuntu-2004-general'
-      vmImage: 'ubuntu-20.04'
-    strategy:
-      matrix:
-        EventHub Python 3.9:
-          PythonVersion: '$(PythonVersion39)'
-          SDK: 'EventHub'
-        EventHub Python 3.12:
-          PythonVersion: '$(PythonVersion312)'
-          SDK: 'EventHub'
-        ServiceBus Python 3.9:
-          PythonVersion: '$(PythonVersion39)'
-          SDK: 'ServiceBus'
-        ServiceBus Python 3.12:
-          PythonVersion: '$(PythonVersion312)'
-          SDK: 'ServiceBus'
-    variables:
-      OSArch: 'Linux'
-      DownloadArtifactFolder: 'uamqp-linux-$(PythonVersion)-whl'
-    steps:
-      - template: /.azure-pipelines/use-python-version.yml
-        parameters:
-          versionSpec: '$(PythonVersion)'
-      - template: /.azure-pipelines/test-eh-sb-sdk.yml
+  #- job: 'SDK_LiveTest_ubuntu1804'
+  #  timeoutInMinutes: 300
+  #  dependsOn: 'Linux'
+  #  pool:
+  #    name: 'azsdk-pool-mms-ubuntu-2004-general'
+  #    vmImage: 'ubuntu-20.04'
+  #  strategy:
+  #    matrix:
+  #      EventHub Python 3.9:
+  #        PythonVersion: '$(PythonVersion39)'
+  #        SDK: 'EventHub'
+  #      EventHub Python 3.12:
+  #        PythonVersion: '$(PythonVersion312)'
+  #        SDK: 'EventHub'
+  #      ServiceBus Python 3.9:
+  #        PythonVersion: '$(PythonVersion39)'
+  #        SDK: 'ServiceBus'
+  #      ServiceBus Python 3.12:
+  #        PythonVersion: '$(PythonVersion312)'
+  #        SDK: 'ServiceBus'
+  #  variables:
+  #    OSArch: 'Linux'
+  #    DownloadArtifactFolder: 'uamqp-linux-$(PythonVersion)-whl'
+  #  steps:
+  #    - template: /.azure-pipelines/use-python-version.yml
+  #      parameters:
+  #        versionSpec: '$(PythonVersion)'
+  #    - template: /.azure-pipelines/test-eh-sb-sdk.yml

--- a/.azure-pipelines/client.test.live.yml
+++ b/.azure-pipelines/client.test.live.yml
@@ -346,7 +346,7 @@ jobs:
           pathToPublish: 'dist'
 
   - job: 'SDK_LiveTest_windows2019'
-    timeoutInMinutes: 420
+    timeoutInMinutes: 300
     dependsOn: 'Windows'
     pool:
       name: azsdk-pool-mms-win-2022-general

--- a/.azure-pipelines/client.test.live.yml
+++ b/.azure-pipelines/client.test.live.yml
@@ -29,22 +29,22 @@ jobs:
           PythonArchitecture: 'x64'
           PythonVersion: '$(PythonVersion38)'
           BWFilter: 'cp38-win_amd64'
-        #x64 Python 3.9:
-        #  PythonArchitecture: 'x64'
-        #  PythonVersion: '$(PythonVersion39)'
-        #  BWFilter: 'cp39-win_amd64'
-        #x64 Python 3.10:
-        #  PythonArchitecture: 'x64'
-        #  PythonVersion: '$(PythonVersion310)'
-        #  BWFilter: 'cp310-win_amd64'
-        #x64 Python 3.11:
-        #  PythonArchitecture: 'x64'
-        #  PythonVersion: '$(PythonVersion311)'
-        #  BWFilter: 'cp311-win_amd64'
-        #x64 Python 3.12:
-        #  PythonArchitecture: 'x64'
-        #  PythonVersion: '$(PythonVersion312)'
-        #  BWFilter: 'cp312-win_amd64'
+        x64 Python 3.9:
+          PythonArchitecture: 'x64'
+          PythonVersion: '$(PythonVersion39)'
+          BWFilter: 'cp39-win_amd64'
+        x64 Python 3.10:
+          PythonArchitecture: 'x64'
+          PythonVersion: '$(PythonVersion310)'
+          BWFilter: 'cp310-win_amd64'
+        x64 Python 3.11:
+          PythonArchitecture: 'x64'
+          PythonVersion: '$(PythonVersion311)'
+          BWFilter: 'cp311-win_amd64'
+        x64 Python 3.12:
+          PythonArchitecture: 'x64'
+          PythonVersion: '$(PythonVersion312)'
+          BWFilter: 'cp312-win_amd64'
             
     steps:
       - template: /.azure-pipelines/use-python-version.yml
@@ -128,222 +128,222 @@ jobs:
           artifactName: uamqp-win$(PythonArchitecture)-$(PythonVersion)-whl
           pathToPublish: 'dist'
 
-  #- job: 'MacOS'
+  - job: 'MacOS'
 
-  #  timeoutInMinutes: 120
+    timeoutInMinutes: 120
 
-  #  dependsOn: 'Windows'
+    dependsOn: 'Windows'
 
-  #  pool:
-  #    vmImage: 'macos-latest'
+    pool:
+      vmImage: 'macos-latest'
 
-  #  strategy:
-  #    maxParallel: 1
-  #    matrix:
-  #      Python 3.8:
-  #        PythonBin: 'python3'
-  #        PythonVersion: '$(PythonVersion38)'
-  #        BWFilter: 'cp38-macosx_x86_64'
-  #      Python 3.9:
-  #        PythonBin: 'python3'
-  #        PythonVersion: '$(PythonVersion39)'
-  #        BWFilter: 'cp39-macosx_x86_64'
-  #      Python 3.10:
-  #        PythonBin: 'python3'
-  #        PythonVersion: '$(PythonVersion310)'
-  #        BWFilter: 'cp310-macosx_x86_64'
-  #      Python 3.11:
-  #        PythonBin: 'python3'
-  #        PythonVersion: '$(PythonVersion311)'
-  #        BWFilter: 'cp311-macosx_x86_64'
-  #      Python 3.12:
-  #        PythonBin: 'python3'
-  #        PythonVersion: '$(PythonVersion312)'
-  #        BWFilter: 'cp312-macosx_x86_64'
+    strategy:
+      maxParallel: 1
+      matrix:
+        Python 3.8:
+          PythonBin: 'python3'
+          PythonVersion: '$(PythonVersion38)'
+          BWFilter: 'cp38-macosx_x86_64'
+        Python 3.9:
+          PythonBin: 'python3'
+          PythonVersion: '$(PythonVersion39)'
+          BWFilter: 'cp39-macosx_x86_64'
+        Python 3.10:
+          PythonBin: 'python3'
+          PythonVersion: '$(PythonVersion310)'
+          BWFilter: 'cp310-macosx_x86_64'
+        Python 3.11:
+          PythonBin: 'python3'
+          PythonVersion: '$(PythonVersion311)'
+          BWFilter: 'cp311-macosx_x86_64'
+        Python 3.12:
+          PythonBin: 'python3'
+          PythonVersion: '$(PythonVersion312)'
+          BWFilter: 'cp312-macosx_x86_64'
 
-  #  variables:
-  #    MacOSXDeploymentTarget: '10.9'
-  #    OpenSSLDir: $(Agent.BuildDirectory)/openssl-macosx$(MacOSXDeploymentTarget)
-  #    PythonVersion38: '3.8'
-  #    PythonVersion39: '3.9'
-  #    PythonVersion310: '3.10'
-  #    PythonVersion311: '3.11'
-  #    PythonVersion312: '3.12'
+    variables:
+      MacOSXDeploymentTarget: '10.9'
+      OpenSSLDir: $(Agent.BuildDirectory)/openssl-macosx$(MacOSXDeploymentTarget)
+      PythonVersion38: '3.8'
+      PythonVersion39: '3.9'
+      PythonVersion310: '3.10'
+      PythonVersion311: '3.11'
+      PythonVersion312: '3.12'
 
-  #  steps:
-  #    - task: DownloadPipelineArtifact@1
-  #      displayName: 'Download OpenSSL artifact'
-  #      inputs:
-  #        artifactName: openssl-macosx$(MacOSXDeploymentTarget)
-  #        buildType: specific
-  #        buildVersionToDownload: latest
-  #        downloadPath: $(Agent.BuildDirectory)
-  #        pipeline: 119 # azure-uamqp-python - openssl
-  #        project: '29ec6040-b234-4e31-b139-33dc4287b756' # public
+    steps:
+      - task: DownloadPipelineArtifact@1
+        displayName: 'Download OpenSSL artifact'
+        inputs:
+          artifactName: openssl-macosx$(MacOSXDeploymentTarget)
+          buildType: specific
+          buildVersionToDownload: latest
+          downloadPath: $(Agent.BuildDirectory)
+          pipeline: 119 # azure-uamqp-python - openssl
+          project: '29ec6040-b234-4e31-b139-33dc4287b756' # public
 
-  #    - script: sudo xcode-select --switch /Applications/Xcode_13.1.app
-  #      displayName: 'Select Xcode 13.1'
+      - script: sudo xcode-select --switch /Applications/Xcode_13.1.app
+        displayName: 'Select Xcode 13.1'
 
-  #    - template: /.azure-pipelines/use-python-version.yml
-  #      parameters:
-  #        versionSpec: '$(PythonVersion)'
+      - template: /.azure-pipelines/use-python-version.yml
+        parameters:
+          versionSpec: '$(PythonVersion)'
 
-  #    - script: |
-  #        python -m pip --version
-  #        python -m pip install --user -r dev_requirements.txt
-  #      displayName: 'Install dependencies'
+      - script: |
+          python -m pip --version
+          python -m pip install --user -r dev_requirements.txt
+        displayName: 'Install dependencies'
   
-  #    - bash: |
-  #        set -o errexit
-  #        python -m pip install cibuildwheel==2.16.2 --force
-  #      displayName: Install cibuildwheel 2.16.2
+      - bash: |
+          set -o errexit
+          python -m pip install cibuildwheel==2.16.2 --force
+        displayName: Install cibuildwheel 2.16.2
 
-  #    - pwsh: |
-  #        cibuildwheel --output-dir dist .
-  #      displayName: 'Build uAMQP Wheel'
-  #      env:
-  #        CIBW_PRERELEASE_PYTHONS: True
-  #        CIBW_ARCHS_MACOS: x86_64
-  #        CIBW_BUILD: $(BWFilter)
-  #        UAMQP_USE_OPENSSL: true
-  #        UAMQP_REBUILD_PYX: true
-  #        UAMQP_SUPPRESS_LINK_FLAGS: true
-  #        OPENSSL_ROOT_DIR: "/tmp/openssl"
-  #        OPENSSL_INCLUDE_DIR: "/tmp/openssl/include"
-  #        LDFLAGS: "-mmacosx-version-min=10.9 -L/tmp/openssl/lib"
-  #        CFLAGS: "-mmacosx-version-min=10.9 -I/tmp/openssl/include"
+      - pwsh: |
+          cibuildwheel --output-dir dist .
+        displayName: 'Build uAMQP Wheel'
+        env:
+          CIBW_PRERELEASE_PYTHONS: True
+          CIBW_ARCHS_MACOS: x86_64
+          CIBW_BUILD: $(BWFilter)
+          UAMQP_USE_OPENSSL: true
+          UAMQP_REBUILD_PYX: true
+          UAMQP_SUPPRESS_LINK_FLAGS: true
+          OPENSSL_ROOT_DIR: "/tmp/openssl"
+          OPENSSL_INCLUDE_DIR: "/tmp/openssl/include"
+          LDFLAGS: "-mmacosx-version-min=10.9 -L/tmp/openssl/lib"
+          CFLAGS: "-mmacosx-version-min=10.9 -I/tmp/openssl/include"
 
-  #    - script: ls ./dist
-  #      displayName: 'Check output'
+      - script: ls ./dist
+        displayName: 'Check output'
 
-  #    - script: |
-  #        python -m pip install --ignore-installed ./dist/*.whl
-  #        python -m pip install pytest==6.2.4 --force
-  #        python -m pip install pytest-asyncio==0.12.0 --force
-  #        pytest tests --doctest-modules --junitxml=junit/test-results-c.xml
-  #        pytest samples --doctest-modules --junitxml=junit/test-results-live.xml
-  #      displayName: 'Run tests'
-  #      env:
-  #        EVENT_HUB_HOSTNAME: $(python-eh-livetest-event-hub-hostname)
-  #        EVENT_HUB_NAME: $(python-eh-livetest-event-hub-name)
-  #        EVENT_HUB_SAS_POLICY: $(python-eh-livetest-event-hub-sas-policy)
-  #        EVENT_HUB_SAS_KEY: $(python-eh-livetest-event-hub-sas-key)
-  #        IOTHUB_HOSTNAME: $(python-iothub-livetest-host-name)
-  #        IOTHUB_HUB_NAME: $(python-iothub-livetest-hub-name)
-  #        IOTHUB_DEVICE: $(python-eh-livetest-event-hub-iothub-device)
-  #        IOTHUB_ENDPOINT: $(python-iothub-livetest-endpoint)
-  #        IOTHUB_SAS_POLICY: $(python-iothub-livetest-sas-policy)
-  #        IOTHUB_SAS_KEY: $(python-iothub-livetest-sas-key)
+      - script: |
+          python -m pip install --ignore-installed ./dist/*.whl
+          python -m pip install pytest==6.2.4 --force
+          python -m pip install pytest-asyncio==0.12.0 --force
+          pytest tests --doctest-modules --junitxml=junit/test-results-c.xml
+          pytest samples --doctest-modules --junitxml=junit/test-results-live.xml
+        displayName: 'Run tests'
+        env:
+          EVENT_HUB_HOSTNAME: $(python-eh-livetest-event-hub-hostname)
+          EVENT_HUB_NAME: $(python-eh-livetest-event-hub-name)
+          EVENT_HUB_SAS_POLICY: $(python-eh-livetest-event-hub-sas-policy)
+          EVENT_HUB_SAS_KEY: $(python-eh-livetest-event-hub-sas-key)
+          IOTHUB_HOSTNAME: $(python-iothub-livetest-host-name)
+          IOTHUB_HUB_NAME: $(python-iothub-livetest-hub-name)
+          IOTHUB_DEVICE: $(python-eh-livetest-event-hub-iothub-device)
+          IOTHUB_ENDPOINT: $(python-iothub-livetest-endpoint)
+          IOTHUB_SAS_POLICY: $(python-iothub-livetest-sas-policy)
+          IOTHUB_SAS_KEY: $(python-iothub-livetest-sas-key)
 
-  #    - task: PublishTestResults@2
-  #      displayName: 'Publish test results'
-  #      condition: succeededOrFailed()
-  #      inputs:
-  #        testResultsFiles: '**/test-results-*.xml'
-  #        testResultsFormat: 'JUnit'
-  #        testRunTitle: 'MacOS Python $(PythonVersion)'
+      - task: PublishTestResults@2
+        displayName: 'Publish test results'
+        condition: succeededOrFailed()
+        inputs:
+          testResultsFiles: '**/test-results-*.xml'
+          testResultsFormat: 'JUnit'
+          testRunTitle: 'MacOS Python $(PythonVersion)'
 
-  #    - task: PublishBuildArtifacts@1
-  #      displayName: 'Publish wheel artifact'
-  #      inputs:
-  #        artifactName: uamqp-macosx$(MacOSXDeploymentTarget)-$(PythonVersion)-whl
-  #        pathToPublish: 'dist'
+      - task: PublishBuildArtifacts@1
+        displayName: 'Publish wheel artifact'
+        inputs:
+          artifactName: uamqp-macosx$(MacOSXDeploymentTarget)-$(PythonVersion)-whl
+          pathToPublish: 'dist'
 
-  #- job: 'Linux'
+  - job: 'Linux'
 
-  #  timeoutInMinutes: 120
+    timeoutInMinutes: 120
 
-  #  dependsOn: 'MacOS'
+    dependsOn: 'MacOS'
 
-  #  pool:
-  #    vmImage: 'ubuntu-20.04'
+    pool:
+      vmImage: 'ubuntu-20.04'
 
-  #  strategy:
-  #    maxParallel: 1
-  #    matrix:
-  #      Python 3.8:
-  #        PythonVersion: '$(PythonVersion38)'
-  #        BWFilter: 'cp38-manylinux_x86_64'
-  #      Python 3.9:
-  #        PythonVersion: '$(PythonVersion39)'
-  #        BWFilter: 'cp39-manylinux_x86_64'
-  #      Python 3.10:
-  #        PythonVersion: '$(PythonVersion310)'
-  #        BWFilter: 'cp310-manylinux_x86_64'
-  #      Python 3.11:
-  #        PythonVersion: '$(PythonVersion311)'
-  #        BWFilter: 'cp311-manylinux_x86_64'
-  #      Python 3.12:
-  #        PythonVersion: '$(PythonVersion312)'
-  #        BWFilter: 'cp312-manylinux_x86_64'
+    strategy:
+      maxParallel: 1
+      matrix:
+        Python 3.8:
+          PythonVersion: '$(PythonVersion38)'
+          BWFilter: 'cp38-manylinux_x86_64'
+        Python 3.9:
+          PythonVersion: '$(PythonVersion39)'
+          BWFilter: 'cp39-manylinux_x86_64'
+        Python 3.10:
+          PythonVersion: '$(PythonVersion310)'
+          BWFilter: 'cp310-manylinux_x86_64'
+        Python 3.11:
+          PythonVersion: '$(PythonVersion311)'
+          BWFilter: 'cp311-manylinux_x86_64'
+        Python 3.12:
+          PythonVersion: '$(PythonVersion312)'
+          BWFilter: 'cp312-manylinux_x86_64'
 
-  #  steps:
-  #    - template: /.azure-pipelines/use-python-version.yml
-  #      parameters:
-  #        versionSpec: '$(PythonVersion)'
+    steps:
+      - template: /.azure-pipelines/use-python-version.yml
+        parameters:
+          versionSpec: '$(PythonVersion)'
 
-  #    - script: |
-  #        echo "Prepending PATH environment variable with directory: $HOME/.local/bin"
-  #        echo "##vso[task.prependpath]$HOME/.local/bin"
-  #      displayName: 'Prepare PATH'
+      - script: |
+          echo "Prepending PATH environment variable with directory: $HOME/.local/bin"
+          echo "##vso[task.prependpath]$HOME/.local/bin"
+        displayName: 'Prepare PATH'
 
-  #    - script: |
-  #        python --version
-  #        curl -sS $(GetPip) | python - --user
-  #        python -m pip --version
-  #        python -m pip install setuptools --force
-  #        curl -LO http://archive.ubuntu.com/ubuntu/pool/main/libf/libffi/libffi6_3.2.1-8_amd64.deb && sudo dpkg -i libffi6_3.2.1-8_amd64.deb
-  #        python -m pip install --user -r dev_requirements.txt
-  #      displayName: 'Install dependencies'
+      - script: |
+          python --version
+          curl -sS $(GetPip) | python - --user
+          python -m pip --version
+          python -m pip install setuptools --force
+          curl -LO http://archive.ubuntu.com/ubuntu/pool/main/libf/libffi/libffi6_3.2.1-8_amd64.deb && sudo dpkg -i libffi6_3.2.1-8_amd64.deb
+          python -m pip install --user -r dev_requirements.txt
+        displayName: 'Install dependencies'
 
-  #    - bash: |
-  #        set -o errexit
-  #        python -m pip install cibuildwheel==2.16.2
-  #      displayName: Install cibuildwheel 2.16.2
+      - bash: |
+          set -o errexit
+          python -m pip install cibuildwheel==2.16.2
+        displayName: Install cibuildwheel 2.16.2
 
-  #    - pwsh: |
-  #        cibuildwheel --output-dir dist .
-  #      displayName: 'Build uAMQP Wheel'
-  #      env:
-  #        CIBW_BUILD: $(BWFilter)
-  #        CIBW_PRERELEASE_PYTHONS: True
-  #        CIBW_BEFORE_BUILD_LINUX: bash utils/install_openssl.sh
-  #        CIBW_ENVIRONMENT_LINUX: OPENSSL_ROOT_DIR="/opt/pyca/cryptography/openssl" LIBRARY_PATH="/opt/pyca/cryptography/openssl/lib" CPATH="/opt/pyca/cryptography/openssl/include" CIBW_ARCHS_LINUX="x86_64"
+      - pwsh: |
+          cibuildwheel --output-dir dist .
+        displayName: 'Build uAMQP Wheel'
+        env:
+          CIBW_BUILD: $(BWFilter)
+          CIBW_PRERELEASE_PYTHONS: True
+          CIBW_BEFORE_BUILD_LINUX: bash utils/install_openssl.sh
+          CIBW_ENVIRONMENT_LINUX: OPENSSL_ROOT_DIR="/opt/pyca/cryptography/openssl" LIBRARY_PATH="/opt/pyca/cryptography/openssl/lib" CPATH="/opt/pyca/cryptography/openssl/include" CIBW_ARCHS_LINUX="x86_64"
 
-  #    - script: ls ./dist
-  #      displayName: 'Check output'
+      - script: ls ./dist
+        displayName: 'Check output'
 
-  #    - script: |
-  #        python -m pip install --user --ignore-installed ./dist/*.whl
-  #        python -m pip install --user pytest==6.2.4 --force
-  #        pytest tests --doctest-modules --junitxml=junit/test-results-c.xml
-  #        pytest samples --doctest-modules --junitxml=junit/test-results-live.xml
-  #      displayName: 'Run tests'
-  #      env:
-  #        EVENT_HUB_HOSTNAME: $(python-eh-livetest-event-hub-hostname)
-  #        EVENT_HUB_NAME: $(python-eh-livetest-event-hub-name)
-  #        EVENT_HUB_SAS_POLICY: $(python-eh-livetest-event-hub-sas-policy)
-  #        EVENT_HUB_SAS_KEY: $(python-eh-livetest-event-hub-sas-key)
-  #        IOTHUB_HOSTNAME: $(python-iothub-livetest-host-name)
-  #        IOTHUB_HUB_NAME: $(python-iothub-livetest-hub-name)
-  #        IOTHUB_DEVICE: $(python-eh-livetest-event-hub-iothub-device)
-  #        IOTHUB_ENDPOINT: $(python-iothub-livetest-endpoint)
-  #        IOTHUB_SAS_POLICY: $(python-iothub-livetest-sas-policy)
-  #        IOTHUB_SAS_KEY: $(python-iothub-livetest-sas-key)
+      - script: |
+          python -m pip install --user --ignore-installed ./dist/*.whl
+          python -m pip install --user pytest==6.2.4 --force
+          pytest tests --doctest-modules --junitxml=junit/test-results-c.xml
+          pytest samples --doctest-modules --junitxml=junit/test-results-live.xml
+        displayName: 'Run tests'
+        env:
+          EVENT_HUB_HOSTNAME: $(python-eh-livetest-event-hub-hostname)
+          EVENT_HUB_NAME: $(python-eh-livetest-event-hub-name)
+          EVENT_HUB_SAS_POLICY: $(python-eh-livetest-event-hub-sas-policy)
+          EVENT_HUB_SAS_KEY: $(python-eh-livetest-event-hub-sas-key)
+          IOTHUB_HOSTNAME: $(python-iothub-livetest-host-name)
+          IOTHUB_HUB_NAME: $(python-iothub-livetest-hub-name)
+          IOTHUB_DEVICE: $(python-eh-livetest-event-hub-iothub-device)
+          IOTHUB_ENDPOINT: $(python-iothub-livetest-endpoint)
+          IOTHUB_SAS_POLICY: $(python-iothub-livetest-sas-policy)
+          IOTHUB_SAS_KEY: $(python-iothub-livetest-sas-key)
 
-  #    - task: PublishTestResults@2
-  #      displayName: 'Publish test results'
-  #      condition: succeededOrFailed()
-  #      inputs:
-  #        testResultsFiles: '**/test-results-*.xml'
-  #        testResultsFormat: 'JUnit'
-  #        testRunTitle: 'Linux Python $(PythonVersion)'
+      - task: PublishTestResults@2
+        displayName: 'Publish test results'
+        condition: succeededOrFailed()
+        inputs:
+          testResultsFiles: '**/test-results-*.xml'
+          testResultsFormat: 'JUnit'
+          testRunTitle: 'Linux Python $(PythonVersion)'
 
-  #    - task: PublishBuildArtifacts@1
-  #      displayName: 'Publish wheel artifact'
-  #      inputs:
-  #        artifactName: uamqp-linux-$(PythonVersion)-whl
-  #        pathToPublish: 'dist'
+      - task: PublishBuildArtifacts@1
+        displayName: 'Publish wheel artifact'
+        inputs:
+          artifactName: uamqp-linux-$(PythonVersion)-whl
+          pathToPublish: 'dist'
 
   - job: 'SDK_LiveTest_windows2019'
     timeoutInMinutes: 420
@@ -353,18 +353,18 @@ jobs:
       vmImage: windows-2022
     strategy:
       matrix:
-        #EventHub x64 Python 3.8:
-        #  PythonVersion: '$(PythonVersion38)'
-        #  SDK: 'EventHub'
-        #EventHub x64 Python 3.12:
-        #  PythonVersion: '$(PythonVersion312)'
-        #  SDK: 'EventHub'
+        EventHub x64 Python 3.8:
+          PythonVersion: '$(PythonVersion38)'
+          SDK: 'EventHub'
+        EventHub x64 Python 3.12:
+          PythonVersion: '$(PythonVersion312)'
+          SDK: 'EventHub'
         ServiceBus x64 Python 3.8:
           PythonVersion: '$(PythonVersion38)'
           SDK: 'ServiceBus'
-        #ServiceBus x64 Python 3.12:
-        #  PythonVersion: '$(PythonVersion312)'
-        #  SDK: 'ServiceBus'
+        ServiceBus x64 Python 3.12:
+          PythonVersion: '$(PythonVersion312)'
+          SDK: 'ServiceBus'
     variables:
       PythonArchitecture: 'x64'
       OSArch: 'Windows'
@@ -376,56 +376,56 @@ jobs:
           versionSpec: '$(PythonVersion)'
       - template: /.azure-pipelines/test-eh-sb-sdk.yml
 
-  #- job: 'SDK_LiveTest_macOS1015'
-  #  timeoutInMinutes: 300
-  #  dependsOn: 'MacOS'
-  #  pool:
-  #    name: 'Azure Pipelines'
-  #    vmImage: 'macOS-11'
-  #  strategy:
-  #    matrix:
-  #      EventHub Python 3.12:
-  #        SDK: 'EventHub'
-  #      ServiceBus Python 3.12:
-  #        SDK: 'ServiceBus'
-  #  variables:
-  #    PythonBin: 'python3'
-  #    PythonVersion: '3.12.0'
-  #    MacOSXDeploymentTarget: '10.9'
-  #    PythonVersion382: '3.12'
-  #    OSArch: 'MacOS'
-  #    DownloadArtifactFolder: 'uamqp-macosx$(MacOSXDeploymentTarget)-$(PythonVersion)-whl'
-  #  steps:
-  #    - template: /.azure-pipelines/use-python-version.yml
-  #      parameters:
-  #        versionSpec: '$(PythonVersion)'
-  #    - template: /.azure-pipelines/test-eh-sb-sdk.yml
+  - job: 'SDK_LiveTest_macOS1015'
+    timeoutInMinutes: 300
+    dependsOn: 'MacOS'
+    pool:
+      name: 'Azure Pipelines'
+      vmImage: 'macOS-11'
+    strategy:
+      matrix:
+        EventHub Python 3.12:
+          SDK: 'EventHub'
+        ServiceBus Python 3.12:
+          SDK: 'ServiceBus'
+    variables:
+      PythonBin: 'python3'
+      PythonVersion: '3.12.0'
+      MacOSXDeploymentTarget: '10.9'
+      PythonVersion382: '3.12'
+      OSArch: 'MacOS'
+      DownloadArtifactFolder: 'uamqp-macosx$(MacOSXDeploymentTarget)-$(PythonVersion)-whl'
+    steps:
+      - template: /.azure-pipelines/use-python-version.yml
+        parameters:
+          versionSpec: '$(PythonVersion)'
+      - template: /.azure-pipelines/test-eh-sb-sdk.yml
 
-  #- job: 'SDK_LiveTest_ubuntu1804'
-  #  timeoutInMinutes: 300
-  #  dependsOn: 'Linux'
-  #  pool:
-  #    name: 'azsdk-pool-mms-ubuntu-2004-general'
-  #    vmImage: 'ubuntu-20.04'
-  #  strategy:
-  #    matrix:
-  #      EventHub Python 3.9:
-  #        PythonVersion: '$(PythonVersion39)'
-  #        SDK: 'EventHub'
-  #      EventHub Python 3.12:
-  #        PythonVersion: '$(PythonVersion312)'
-  #        SDK: 'EventHub'
-  #      ServiceBus Python 3.9:
-  #        PythonVersion: '$(PythonVersion39)'
-  #        SDK: 'ServiceBus'
-  #      ServiceBus Python 3.12:
-  #        PythonVersion: '$(PythonVersion312)'
-  #        SDK: 'ServiceBus'
-  #  variables:
-  #    OSArch: 'Linux'
-  #    DownloadArtifactFolder: 'uamqp-linux-$(PythonVersion)-whl'
-  #  steps:
-  #    - template: /.azure-pipelines/use-python-version.yml
-  #      parameters:
-  #        versionSpec: '$(PythonVersion)'
-  #    - template: /.azure-pipelines/test-eh-sb-sdk.yml
+  - job: 'SDK_LiveTest_ubuntu1804'
+    timeoutInMinutes: 300
+    dependsOn: 'Linux'
+    pool:
+      name: 'azsdk-pool-mms-ubuntu-2004-general'
+      vmImage: 'ubuntu-20.04'
+    strategy:
+      matrix:
+        EventHub Python 3.9:
+          PythonVersion: '$(PythonVersion39)'
+          SDK: 'EventHub'
+        EventHub Python 3.12:
+          PythonVersion: '$(PythonVersion312)'
+          SDK: 'EventHub'
+        ServiceBus Python 3.9:
+          PythonVersion: '$(PythonVersion39)'
+          SDK: 'ServiceBus'
+        ServiceBus Python 3.12:
+          PythonVersion: '$(PythonVersion312)'
+          SDK: 'ServiceBus'
+    variables:
+      OSArch: 'Linux'
+      DownloadArtifactFolder: 'uamqp-linux-$(PythonVersion)-whl'
+    steps:
+      - template: /.azure-pipelines/use-python-version.yml
+        parameters:
+          versionSpec: '$(PythonVersion)'
+      - template: /.azure-pipelines/test-eh-sb-sdk.yml

--- a/.azure-pipelines/client.test.live.yml
+++ b/.azure-pipelines/client.test.live.yml
@@ -135,7 +135,7 @@ jobs:
     dependsOn: 'Windows'
 
     pool:
-      vmImage: 'macOS-11'
+      vmImage: 'macos-latest'
 
     strategy:
       maxParallel: 1

--- a/.azure-pipelines/client.test.live.yml
+++ b/.azure-pipelines/client.test.live.yml
@@ -356,15 +356,15 @@ jobs:
         EventHub x64 Python 3.8:
           PythonVersion: '$(PythonVersion38)'
           SDK: 'EventHub'
-        EventHub x64 Python 3.12:
-          PythonVersion: '$(PythonVersion312)'
-          SDK: 'EventHub'
+        #EventHub x64 Python 3.12:
+        #  PythonVersion: '$(PythonVersion312)'
+        #  SDK: 'EventHub'
         ServiceBus x64 Python 3.8:
           PythonVersion: '$(PythonVersion38)'
           SDK: 'ServiceBus'
-        ServiceBus x64 Python 3.12:
-          PythonVersion: '$(PythonVersion312)'
-          SDK: 'ServiceBus'
+        #ServiceBus x64 Python 3.12:
+        #  PythonVersion: '$(PythonVersion312)'
+        #  SDK: 'ServiceBus'
     variables:
       PythonArchitecture: 'x64'
       OSArch: 'Windows'
@@ -376,56 +376,56 @@ jobs:
           versionSpec: '$(PythonVersion)'
       - template: /.azure-pipelines/test-eh-sb-sdk.yml
 
-  - job: 'SDK_LiveTest_macOS1015'
-    timeoutInMinutes: 300
-    dependsOn: 'MacOS'
-    pool:
-      name: 'Azure Pipelines'
-      vmImage: 'macOS-11'
-    strategy:
-      matrix:
-        EventHub Python 3.12:
-          SDK: 'EventHub'
-        ServiceBus Python 3.12:
-          SDK: 'ServiceBus'
-    variables:
-      PythonBin: 'python3'
-      PythonVersion: '3.12.0'
-      MacOSXDeploymentTarget: '10.9'
-      PythonVersion382: '3.12'
-      OSArch: 'MacOS'
-      DownloadArtifactFolder: 'uamqp-macosx$(MacOSXDeploymentTarget)-$(PythonVersion)-whl'
-    steps:
-      - template: /.azure-pipelines/use-python-version.yml
-        parameters:
-          versionSpec: '$(PythonVersion)'
-      - template: /.azure-pipelines/test-eh-sb-sdk.yml
+  #- job: 'SDK_LiveTest_macOS1015'
+  #  timeoutInMinutes: 300
+  #  dependsOn: 'MacOS'
+  #  pool:
+  #    name: 'Azure Pipelines'
+  #    vmImage: 'macOS-11'
+  #  strategy:
+  #    matrix:
+  #      EventHub Python 3.12:
+  #        SDK: 'EventHub'
+  #      ServiceBus Python 3.12:
+  #        SDK: 'ServiceBus'
+  #  variables:
+  #    PythonBin: 'python3'
+  #    PythonVersion: '3.12.0'
+  #    MacOSXDeploymentTarget: '10.9'
+  #    PythonVersion382: '3.12'
+  #    OSArch: 'MacOS'
+  #    DownloadArtifactFolder: 'uamqp-macosx$(MacOSXDeploymentTarget)-$(PythonVersion)-whl'
+  #  steps:
+  #    - template: /.azure-pipelines/use-python-version.yml
+  #      parameters:
+  #        versionSpec: '$(PythonVersion)'
+  #    - template: /.azure-pipelines/test-eh-sb-sdk.yml
 
-  - job: 'SDK_LiveTest_ubuntu1804'
-    timeoutInMinutes: 300
-    dependsOn: 'Linux'
-    pool:
-      name: 'azsdk-pool-mms-ubuntu-2004-general'
-      vmImage: 'ubuntu-20.04'
-    strategy:
-      matrix:
-        EventHub Python 3.9:
-          PythonVersion: '$(PythonVersion39)'
-          SDK: 'EventHub'
-        EventHub Python 3.12:
-          PythonVersion: '$(PythonVersion312)'
-          SDK: 'EventHub'
-        ServiceBus Python 3.9:
-          PythonVersion: '$(PythonVersion39)'
-          SDK: 'ServiceBus'
-        ServiceBus Python 3.12:
-          PythonVersion: '$(PythonVersion312)'
-          SDK: 'ServiceBus'
-    variables:
-      OSArch: 'Linux'
-      DownloadArtifactFolder: 'uamqp-linux-$(PythonVersion)-whl'
-    steps:
-      - template: /.azure-pipelines/use-python-version.yml
-        parameters:
-          versionSpec: '$(PythonVersion)'
-      - template: /.azure-pipelines/test-eh-sb-sdk.yml
+  #- job: 'SDK_LiveTest_ubuntu1804'
+  #  timeoutInMinutes: 300
+  #  dependsOn: 'Linux'
+  #  pool:
+  #    name: 'azsdk-pool-mms-ubuntu-2004-general'
+  #    vmImage: 'ubuntu-20.04'
+  #  strategy:
+  #    matrix:
+  #      EventHub Python 3.9:
+  #        PythonVersion: '$(PythonVersion39)'
+  #        SDK: 'EventHub'
+  #      EventHub Python 3.12:
+  #        PythonVersion: '$(PythonVersion312)'
+  #        SDK: 'EventHub'
+  #      ServiceBus Python 3.9:
+  #        PythonVersion: '$(PythonVersion39)'
+  #        SDK: 'ServiceBus'
+  #      ServiceBus Python 3.12:
+  #        PythonVersion: '$(PythonVersion312)'
+  #        SDK: 'ServiceBus'
+  #  variables:
+  #    OSArch: 'Linux'
+  #    DownloadArtifactFolder: 'uamqp-linux-$(PythonVersion)-whl'
+  #  steps:
+  #    - template: /.azure-pipelines/use-python-version.yml
+  #      parameters:
+  #        versionSpec: '$(PythonVersion)'
+  #    - template: /.azure-pipelines/test-eh-sb-sdk.yml

--- a/.azure-pipelines/client.test.live.yml
+++ b/.azure-pipelines/client.test.live.yml
@@ -381,7 +381,7 @@ jobs:
     dependsOn: 'MacOS'
     pool:
       name: 'Azure Pipelines'
-      vmImage: 'macOS-11'
+      vmImage: 'macos-latest'
     strategy:
       matrix:
         EventHub Python 3.12:

--- a/.azure-pipelines/client.test.live.yml
+++ b/.azure-pipelines/client.test.live.yml
@@ -390,9 +390,8 @@ jobs:
           SDK: 'ServiceBus'
     variables:
       PythonBin: 'python3'
-      PythonVersion: '3.12.0'
+      PythonVersion: '3.12'
       MacOSXDeploymentTarget: '10.9'
-      PythonVersion382: '3.12'
       OSArch: 'MacOS'
       DownloadArtifactFolder: 'uamqp-macosx$(MacOSXDeploymentTarget)-$(PythonVersion)-whl'
     steps:

--- a/.azure-pipelines/test-eh-sb-sdk.yml
+++ b/.azure-pipelines/test-eh-sb-sdk.yml
@@ -36,7 +36,7 @@ steps:
   - script: |
       echo "SDKPath: $(SdkPath)"
       echo "Tests: $(TestResultsPath)"
-      git clone -b swathipil/devtools/log-pipelinecred-usage https://github.com/swathipil/azure-sdk-for-python.git --single-branch --depth 1
+      git clone -b swathipil/sb/allow-not-testing-pyamqp https://github.com/swathipil/azure-sdk-for-python.git --single-branch --depth 1
     displayName: 'Clone azure-sdk-for-python'
   - task: AzurePowerShell@5
     inputs:

--- a/.azure-pipelines/test-eh-sb-sdk.yml
+++ b/.azure-pipelines/test-eh-sb-sdk.yml
@@ -1,26 +1,38 @@
 steps:
-  - pwsh: |
-      $EHSdkPath='azure-sdk-for-python/sdk/eventhub/azure-eventhub'
-      $EHTestResultsPath='eventhub/azure-eventhub/test-results-live.xml'
-      $EHIgnoreTests='--ignore=tests/perfstress_tests --ignore=tests/scripts'
-      $EHSdkType='eventhub'
-      Write-Output "##vso[task.setvariable variable=SdkType;]$EHSdkType"
-      Write-Output "##vso[task.setvariable variable=SdkPath;]$EHSdkPath"
-      Write-Output "##vso[task.setvariable variable=TestResultsPath;]$EHTestResultsPath"
-      Write-Output "##vso[task.setvariable variable=IgnoreTests;]$EHIgnoreTests"
-    condition: eq(variables['SDK'], 'EventHub')
+  - task: AzurePowerShell@5
     displayName: 'Get variables if EventHub'
-  - pwsh: |
-      $SBSdkPath='azure-sdk-for-python/sdk/servicebus/azure-servicebus'
-      $SBTestResultsPath='servicebus/azure-servicebus/test-results-live.xml'
-      $SBIgnoreTests='--ignore=tests/perf_tests --ignore=tests/stress_tests'
-      $SBSdkType='servicebus'
-      Write-Output "##vso[task.setvariable variable=SdkType;]$SBSdkType"
-      Write-Output "##vso[task.setvariable variable=SdkPath;]$SBSdkPath"
-      Write-Output "##vso[task.setvariable variable=TestResultsPath;]$SBTestResultsPath"
-      Write-Output "##vso[task.setvariable variable=IgnoreTests;]$SBIgnoreTests"
-    condition: eq(variables['SDK'], 'ServiceBus')
+    condition: eq(variables['SDK'], 'EventHub')
+    inputs:
+      azureSubscription: azure-sdk-tests
+      ScriptType: InlineScript
+      azurePowerShellVersion: LatestVersion
+      pwsh: true
+      Inline: |
+        $EHSdkPath='azure-sdk-for-python/sdk/eventhub/azure-eventhub'
+        $EHTestResultsPath='eventhub/azure-eventhub/test-results-live.xml'
+        $EHIgnoreTests='--ignore=tests/perfstress_tests --ignore=tests/scripts'
+        $EHSdkType='eventhub'
+        Write-Output "##vso[task.setvariable variable=SdkType;]$EHSdkType"
+        Write-Output "##vso[task.setvariable variable=SdkPath;]$EHSdkPath"
+        Write-Output "##vso[task.setvariable variable=TestResultsPath;]$EHTestResultsPath"
+        Write-Output "##vso[task.setvariable variable=IgnoreTests;]$EHIgnoreTests"
+  - task: AzurePowerShell@5
     displayName: 'Get variables if ServiceBus'
+    condition: eq(variables['SDK'], 'ServiceBus')
+    inputs:
+      azureSubscription: azure-sdk-tests
+      ScriptType: InlineScript
+      azurePowerShellVersion: LatestVersion
+      pwsh: true
+      Inline: |
+        $SBSdkPath='azure-sdk-for-python/sdk/servicebus/azure-servicebus'
+        $SBTestResultsPath='servicebus/azure-servicebus/test-results-live.xml'
+        $SBIgnoreTests='--ignore=tests/perf_tests --ignore=tests/stress_tests'
+        $SBSdkType='servicebus'
+        Write-Output "##vso[task.setvariable variable=SdkType;]$SBSdkType"
+        Write-Output "##vso[task.setvariable variable=SdkPath;]$SBSdkPath"
+        Write-Output "##vso[task.setvariable variable=TestResultsPath;]$SBTestResultsPath"
+        Write-Output "##vso[task.setvariable variable=IgnoreTests;]$SBIgnoreTests"
   - script: |
       echo "SDKPath: $(SdkPath)"
       echo "Tests: $(TestResultsPath)"
@@ -87,6 +99,8 @@ steps:
         Write-Host (Get-Command python).Source
 
         python --version
+        dir
+        Write-Host "$(Agent.TempDirectory)"
         echo "Installing $DownloadArtifactWhl"
         echo "Full name $(Pipeline.Workspace)/$(DownloadArtifactFolder)/$(DownloadArtifactWhl)"
         python -m pip install $(Pipeline.Workspace)/$(DownloadArtifactFolder)/$(DownloadArtifactWhl) --force

--- a/.azure-pipelines/test-eh-sb-sdk.yml
+++ b/.azure-pipelines/test-eh-sb-sdk.yml
@@ -36,7 +36,7 @@ steps:
   - script: |
       echo "SDKPath: $(SdkPath)"
       echo "Tests: $(TestResultsPath)"
-      git clone https://github.com/Azure/azure-sdk-for-python.git --single-branch --depth 1
+      git clone -b swathipil/devtools/log-pipelinecred-usage https://github.com/swathipil/azure-sdk-for-python.git --single-branch --depth 1
     displayName: 'Clone azure-sdk-for-python'
   - task: AzurePowerShell@5
     inputs:

--- a/.azure-pipelines/test-eh-sb-sdk.yml
+++ b/.azure-pipelines/test-eh-sb-sdk.yml
@@ -75,7 +75,7 @@ steps:
       AZURE_SUBSCRIPTION_ID: $(azure-subscription-id)
       AZURE_TEST_RUN_LIVE: 'true'
     inputs:
-      azureSubscription: ${{ parameters.ServiceConnection }}
+      azureSubscription: azure-sdk-tests
       azurePowerShellVersion: LatestVersion
       pwsh: true
       ScriptType: InlineScript

--- a/.azure-pipelines/test-eh-sb-sdk.yml
+++ b/.azure-pipelines/test-eh-sb-sdk.yml
@@ -87,6 +87,7 @@ steps:
       AZURE_SUBSCRIPTION_ID: $(azure-subscription-id)
       AZURE_TEST_RUN_LIVE: 'true'
       PYTEST_LOG_LEVEL: 'INFO'
+      TEST_PYAMQP: 'false'
     inputs:
       azureSubscription: azure-sdk-tests
       azurePowerShellVersion: LatestVersion

--- a/.azure-pipelines/test-eh-sb-sdk.yml
+++ b/.azure-pipelines/test-eh-sb-sdk.yml
@@ -48,7 +48,7 @@ steps:
           @subscriptionConfiguration `
           -CI `
           -Force `
-          -Verbose | Out-Null `
+          -Verbose | Out-Null
     displayName: Deploy test resources
     env:
         TEMP: $(Agent.TempDirectory)
@@ -107,7 +107,7 @@ steps:
           -ServiceDirectory $(SDKType) `
           -CI `
           -Force `
-          -Verbose `
+          -Verbose
     displayName: Remove test resources
     condition: and(eq(variables['CI_HAS_DEPLOYED_RESOURCES'], 'true'), ne(variables['Skip.RemoveTestResources'], 'true'))
     continueOnError: true

--- a/.azure-pipelines/test-eh-sb-sdk.yml
+++ b/.azure-pipelines/test-eh-sb-sdk.yml
@@ -41,7 +41,8 @@ steps:
         @subscriptionConfiguration `
         -CI `
         -Force `
-        -Verbose | Out-Null
+        -Verbose | Out-Null `
+        -UseFederatedAuth true
     workingDirectory: azure-sdk-for-python
     displayName: Deploy test resources
     env:
@@ -93,7 +94,8 @@ steps:
         -ServiceDirectory $(SDKType) `
         -CI `
         -Force `
-        -Verbose
+        -Verbose `
+        -UseFederatedAuth true
     workingDirectory: azure-sdk-for-python
     displayName: Remove test resources
     condition: and(eq(variables['CI_HAS_DEPLOYED_RESOURCES'], 'true'), ne(variables['Skip.RemoveTestResources'], 'true'))

--- a/.azure-pipelines/test-eh-sb-sdk.yml
+++ b/.azure-pipelines/test-eh-sb-sdk.yml
@@ -74,7 +74,6 @@ steps:
       SYSTEM_ACCESSTOKEN: $(System.AccessToken)
       AZURE_SUBSCRIPTION_ID: $(azure-subscription-id)
       AZURE_TEST_RUN_LIVE: 'true'
-      ${{ insert }}: ${{ parameters.EnvVars }}
     inputs:
       azureSubscription: ${{ parameters.ServiceConnection }}
       azurePowerShellVersion: LatestVersion

--- a/.azure-pipelines/test-eh-sb-sdk.yml
+++ b/.azure-pipelines/test-eh-sb-sdk.yml
@@ -91,7 +91,7 @@ steps:
       azurePowerShellVersion: LatestVersion
       pwsh: true
       ScriptType: InlineScript
-      Inline: >-
+      Inline: |
         $account = (Get-AzContext).Account;
         $env:AZURESUBSCRIPTION_CLIENT_ID = $account.Id;
         $env:AZURESUBSCRIPTION_TENANT_ID = $account.Tenants;
@@ -99,8 +99,6 @@ steps:
         Write-Host (Get-Command python).Source
 
         python --version
-        dir
-        Write-Host "$(Agent.TempDirectory)"
         echo "Installing $DownloadArtifactWhl"
         echo "Full name $(Pipeline.Workspace)/$(DownloadArtifactFolder)/$(DownloadArtifactWhl)"
         python -m pip install $(Pipeline.Workspace)/$(DownloadArtifactFolder)/$(DownloadArtifactWhl) --force

--- a/.azure-pipelines/test-eh-sb-sdk.yml
+++ b/.azure-pipelines/test-eh-sb-sdk.yml
@@ -95,7 +95,7 @@ steps:
         $account = (Get-AzContext).Account;
         $env:AZURESUBSCRIPTION_CLIENT_ID = $account.Id;
         $env:AZURESUBSCRIPTION_TENANT_ID = $account.Tenants;
-        $env:AZURE_SUBSCRIPTION_ID = $account.Subscription.Id;
+        $env:AZURE_SUBSCRIPTION_ID = (Get-AzContext).Subscription.Id;
 
         Write-Host (Get-Command python).Source
 

--- a/.azure-pipelines/test-eh-sb-sdk.yml
+++ b/.azure-pipelines/test-eh-sb-sdk.yml
@@ -28,6 +28,7 @@ steps:
     displayName: 'Clone azure-sdk-for-python'
   - task: AzurePowerShell@5
     inputs:
+      workingDirectory: azure-sdk-for-python
       azureSubscription: azure-sdk-tests
       azurePowerShellVersion: LatestVersion
       pwsh: True
@@ -48,8 +49,6 @@ steps:
           -CI `
           -Force `
           -Verbose | Out-Null `
-
-    workingDirectory: azure-sdk-for-python
     displayName: Deploy test resources
     env:
         TEMP: $(Agent.TempDirectory)
@@ -88,21 +87,27 @@ steps:
       AZURE_CLIENT_ID: $(aad-azure-sdk-test-client-id)
       AZURE_CLIENT_SECRET: $(aad-azure-sdk-test-client-secret)
       AZURE_TEST_RUN_LIVE: 'true'
-  - pwsh: |
-      eng/common/scripts/Import-AzModules.ps1
+  - task: AzurePowerShell@5
+    inputs:
+      workingDirectory: azure-sdk-for-python
+      azureSubscription: azure-sdk-tests
+      azurePowerShellVersion: LatestVersion
+      pwsh: True
+      ScriptType: InlineScript
+      Inline: |
+        eng/common/scripts/Import-AzModules.ps1
 
-      $subscriptionConfiguration = @'
-        $(sub-config-azure-cloud-test-resources)
-      '@ | ConvertFrom-Json -AsHashtable;
+        $subscriptionConfiguration = @'
+          $(sub-config-azure-cloud-test-resources)
+        '@ | ConvertFrom-Json -AsHashtable;
 
-      eng/common/TestResources/Remove-TestResources.ps1 `
-        @subscriptionConfiguration `
-        -ResourceType test `
-        -ServiceDirectory $(SDKType) `
-        -CI `
-        -Force `
-        -Verbose `
-    workingDirectory: azure-sdk-for-python
+        eng/common/TestResources/Remove-TestResources.ps1 `
+          @subscriptionConfiguration `
+          -ResourceType test `
+          -ServiceDirectory $(SDKType) `
+          -CI `
+          -Force `
+          -Verbose `
     displayName: Remove test resources
     condition: and(eq(variables['CI_HAS_DEPLOYED_RESOURCES'], 'true'), ne(variables['Skip.RemoveTestResources'], 'true'))
     continueOnError: true

--- a/.azure-pipelines/test-eh-sb-sdk.yml
+++ b/.azure-pipelines/test-eh-sb-sdk.yml
@@ -84,6 +84,7 @@ steps:
     displayName: Run Tests (AzurePowerShell@5)
     env:
       SYSTEM_ACCESSTOKEN: $(System.AccessToken)
+      AZURE_SUBSCRIPTION_ID: $(azure-subscription-id)
       AZURE_TEST_RUN_LIVE: 'true'
       PYTEST_LOG_LEVEL: 'INFO'
     inputs:
@@ -95,7 +96,6 @@ steps:
         $account = (Get-AzContext).Account;
         $env:AZURESUBSCRIPTION_CLIENT_ID = $account.Id;
         $env:AZURESUBSCRIPTION_TENANT_ID = $account.Tenants;
-        $env:AZURE_SUBSCRIPTION_ID = $account.ExtendedProperties.SubscriptionId;
 
         Write-Host (Get-Command python).Source
 

--- a/.azure-pipelines/test-eh-sb-sdk.yml
+++ b/.azure-pipelines/test-eh-sb-sdk.yml
@@ -36,7 +36,7 @@ steps:
   - script: |
       echo "SDKPath: $(SdkPath)"
       echo "Tests: $(TestResultsPath)"
-      git clone -b swathipil/sb/allow-not-testing-pyamqp https://github.com/swathipil/azure-sdk-for-python.git --single-branch --depth 1
+      git clone https://github.com/Azure/azure-sdk-for-python.git --single-branch --depth 1
     displayName: 'Clone azure-sdk-for-python'
   - task: AzurePowerShell@5
     inputs:

--- a/.azure-pipelines/test-eh-sb-sdk.yml
+++ b/.azure-pipelines/test-eh-sb-sdk.yml
@@ -86,6 +86,7 @@ steps:
       SYSTEM_ACCESSTOKEN: $(System.AccessToken)
       AZURE_SUBSCRIPTION_ID: $(azure-subscription-id)
       AZURE_TEST_RUN_LIVE: 'true'
+      AZURE_LOG_LEVEL: 'INFO'
     inputs:
       azureSubscription: azure-sdk-tests
       azurePowerShellVersion: LatestVersion

--- a/.azure-pipelines/test-eh-sb-sdk.yml
+++ b/.azure-pipelines/test-eh-sb-sdk.yml
@@ -68,22 +68,38 @@ steps:
       runProxy: true
       rootFolder: azure-sdk-for-python
       templateRoot: azure-sdk-for-python
-  - script: |
-      python --version
-      echo "Installing $DownloadArtifactWhl"
-      echo "Full name $(Pipeline.Workspace)/$(DownloadArtifactFolder)/$(DownloadArtifactWhl)"
-      python -m pip install $(Pipeline.Workspace)/$(DownloadArtifactFolder)/$(DownloadArtifactWhl) --force
-      python -m pip install pytest
-      cd $(SdkPath)
-      python -m pip install futures
-      python -m pip install .
-      python -m pip install -r dev_requirements.txt
-      python -m pip list
-      python -m pytest tests -v --doctest-modules $(IgnoreTests) --junitxml=junit/$(TestResultsPath)
-    displayName: 'Run tests'
+  - task: AzurePowerShell@5
+    displayName: Run Tests (AzurePowerShell@5)
     env:
+      SYSTEM_ACCESSTOKEN: $(System.AccessToken)
       AZURE_SUBSCRIPTION_ID: $(azure-subscription-id)
       AZURE_TEST_RUN_LIVE: 'true'
+      ${{ insert }}: ${{ parameters.EnvVars }}
+    inputs:
+      azureSubscription: ${{ parameters.ServiceConnection }}
+      azurePowerShellVersion: LatestVersion
+      pwsh: true
+      ScriptType: InlineScript
+      Inline: >-
+        $account = (Get-AzContext).Account;
+        $env:AZURESUBSCRIPTION_CLIENT_ID = $account.Id;
+        $env:AZURESUBSCRIPTION_TENANT_ID = $account.Tenants;
+
+        Write-Host (Get-Command python).Source
+
+        python --version
+        echo "Installing $DownloadArtifactWhl"
+        echo "Full name $(Pipeline.Workspace)/$(DownloadArtifactFolder)/$(DownloadArtifactWhl)"
+        python -m pip install $(Pipeline.Workspace)/$(DownloadArtifactFolder)/$(DownloadArtifactWhl) --force
+        python -m pip install pytest
+        cd $(SdkPath)
+        python -m pip install futures
+        python -m pip install .
+        python -m pip install -r dev_requirements.txt
+        python -m pip list
+        python -m pytest tests -v --doctest-modules $(IgnoreTests) --junitxml=junit/$(TestResultsPath)
+        Write-Host "Last exit code: $LASTEXITCODE";
+        exit $LASTEXITCODE;
   - task: AzurePowerShell@5
     inputs:
       workingDirectory: azure-sdk-for-python

--- a/.azure-pipelines/test-eh-sb-sdk.yml
+++ b/.azure-pipelines/test-eh-sb-sdk.yml
@@ -26,27 +26,34 @@ steps:
       echo "Tests: $(TestResultsPath)"
       git clone https://github.com/Azure/azure-sdk-for-python.git --single-branch --depth 1
     displayName: 'Clone azure-sdk-for-python'
-  - pwsh: | 
-      eng/common/scripts/Import-AzModules.ps1
+  - task: AzurePowerShell@5
+    inputs:
+      azureSubscription: azure-sdk-tests
+      azurePowerShellVersion: LatestVersion
+      pwsh: True
+      ScriptType: InlineScript
+      Inline: |
+        eng/common/scripts/Import-AzModules.ps1
 
-      $subscriptionConfiguration = @'
-        $(sub-config-azure-cloud-test-resources)
-      '@ | ConvertFrom-Json -AsHashtable;
+        $subscriptionConfiguration = @'
+          $(sub-config-azure-cloud-test-resources)
+        '@ | ConvertFrom-Json -AsHashtable;
 
-      eng/common/TestResources/New-TestResources.ps1 `
-        -ResourceType test `
-        -ServiceDirectory $(SDKType) `
-        -Location westus `
-        -DeleteAfterHours 8 `
-        @subscriptionConfiguration `
-        -CI `
-        -Force `
-        -Verbose | Out-Null `
-        -UseFederatedAuth true
+        eng/common/TestResources/New-TestResources.ps1 `
+          -ResourceType test `
+          -ServiceDirectory $(SDKType) `
+          -Location westus `
+          -DeleteAfterHours 8 `
+          @subscriptionConfiguration `
+          -CI `
+          -Force `
+          -Verbose | Out-Null `
+
     workingDirectory: azure-sdk-for-python
     displayName: Deploy test resources
     env:
         TEMP: $(Agent.TempDirectory)
+        PoolSubnet: $(PoolSubnet)
   - task: DownloadPipelineArtifact@2
     displayName: 'Downloading artifact'
     inputs:
@@ -95,7 +102,6 @@ steps:
         -CI `
         -Force `
         -Verbose `
-        -UseFederatedAuth true
     workingDirectory: azure-sdk-for-python
     displayName: Remove test resources
     condition: and(eq(variables['CI_HAS_DEPLOYED_RESOURCES'], 'true'), ne(variables['Skip.RemoveTestResources'], 'true'))

--- a/.azure-pipelines/test-eh-sb-sdk.yml
+++ b/.azure-pipelines/test-eh-sb-sdk.yml
@@ -84,7 +84,6 @@ steps:
     displayName: Run Tests (AzurePowerShell@5)
     env:
       SYSTEM_ACCESSTOKEN: $(System.AccessToken)
-      AZURE_SUBSCRIPTION_ID: $(azure-subscription-id)
       AZURE_TEST_RUN_LIVE: 'true'
       PYTEST_LOG_LEVEL: 'INFO'
     inputs:
@@ -96,6 +95,7 @@ steps:
         $account = (Get-AzContext).Account;
         $env:AZURESUBSCRIPTION_CLIENT_ID = $account.Id;
         $env:AZURESUBSCRIPTION_TENANT_ID = $account.Tenants;
+        $env:AZURE_SUBSCRIPTION_ID = $account.ExtendedProperties.SubscriptionId;
 
         Write-Host (Get-Command python).Source
 

--- a/.azure-pipelines/test-eh-sb-sdk.yml
+++ b/.azure-pipelines/test-eh-sb-sdk.yml
@@ -83,9 +83,6 @@ steps:
     displayName: 'Run tests'
     env:
       AZURE_SUBSCRIPTION_ID: $(azure-subscription-id)
-      AZURE_TENANT_ID: $(aad-azure-sdk-test-tenant-id)
-      AZURE_CLIENT_ID: $(aad-azure-sdk-test-client-id)
-      AZURE_CLIENT_SECRET: $(aad-azure-sdk-test-client-secret)
       AZURE_TEST_RUN_LIVE: 'true'
   - task: AzurePowerShell@5
     inputs:

--- a/.azure-pipelines/test-eh-sb-sdk.yml
+++ b/.azure-pipelines/test-eh-sb-sdk.yml
@@ -86,7 +86,7 @@ steps:
       SYSTEM_ACCESSTOKEN: $(System.AccessToken)
       AZURE_SUBSCRIPTION_ID: $(azure-subscription-id)
       AZURE_TEST_RUN_LIVE: 'true'
-      AZURE_LOG_LEVEL: 'INFO'
+      PYTEST_LOG_LEVEL: 'INFO'
     inputs:
       azureSubscription: azure-sdk-tests
       azurePowerShellVersion: LatestVersion

--- a/.azure-pipelines/test-eh-sb-sdk.yml
+++ b/.azure-pipelines/test-eh-sb-sdk.yml
@@ -84,9 +84,7 @@ steps:
     displayName: Run Tests (AzurePowerShell@5)
     env:
       SYSTEM_ACCESSTOKEN: $(System.AccessToken)
-      AZURE_SUBSCRIPTION_ID: $(azure-subscription-id)
       AZURE_TEST_RUN_LIVE: 'true'
-      PYTEST_LOG_LEVEL: 'INFO'
       TEST_PYAMQP: 'false'
     inputs:
       azureSubscription: azure-sdk-tests
@@ -97,6 +95,7 @@ steps:
         $account = (Get-AzContext).Account;
         $env:AZURESUBSCRIPTION_CLIENT_ID = $account.Id;
         $env:AZURESUBSCRIPTION_TENANT_ID = $account.Tenants;
+        $env:AZURE_SUBSCRIPTION_ID = $account.Subscription.Id;
 
         Write-Host (Get-Command python).Source
 

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -2,7 +2,7 @@
 
 Release History
 ===============
-1.6.10 (2024-08-21)
+1.6.10 (Unreleased)
 +++++++++++++++++++
 
 - Incorporate fixes from `PR <https://github.com/Azure/azure-sdk-for-cpp/pull/5917>`__ to update vendor uamqp code.

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -2,6 +2,11 @@
 
 Release History
 ===============
+1.6.10 (2024-08-21)
++++++++++++++++++++
+
+- Incorporate fixes from `PR <https://github.com/Azure/azure-sdk-for-cpp/pull/5917>`__ to update vendor uamqp code.
+
 1.6.9 (2024-03-20)
 +++++++++++++++++++
 

--- a/src/vendor/azure-uamqp-c/src/amqp_frame_codec.c
+++ b/src/vendor/azure-uamqp-c/src/amqp_frame_codec.c
@@ -11,6 +11,7 @@
 #include "azure_uamqp_c/amqp_frame_codec.h"
 #include "azure_uamqp_c/frame_codec.h"
 #include "azure_uamqp_c/amqpvalue.h"
+#include "azure_c_shared_utility/safe_math.h"
 
 typedef enum AMQP_FRAME_DECODE_STATE_TAG
 {
@@ -274,10 +275,13 @@ int amqp_frame_codec_encode_frame(AMQP_FRAME_CODEC_HANDLE amqp_frame_codec, uint
             }
             else
             {
-                PAYLOAD* new_payloads = (PAYLOAD*)calloc(1, (sizeof(PAYLOAD) * (payload_count + 1)));
-                if (new_payloads == NULL)
+                PAYLOAD* new_payloads;
+                size_t calloc_size = safe_add_size_t(payload_count, 1);
+                calloc_size = safe_multiply_size_t(calloc_size, sizeof(PAYLOAD));
+                if (calloc_size == SIZE_MAX ||
+                    (new_payloads = (PAYLOAD*)calloc(1, calloc_size)) == NULL)
                 {
-                    LogError("Could not allocate frame payloads");
+                    LogError("Could not allocate frame payloads, size:%zu", calloc_size);
                     result = MU_FAILURE;
                 }
                 else

--- a/src/vendor/azure-uamqp-c/src/amqpvalue.c
+++ b/src/vendor/azure-uamqp-c/src/amqpvalue.c
@@ -1278,11 +1278,12 @@ int amqpvalue_set_list_item_count(AMQP_VALUE value, uint32_t list_size)
                 AMQP_VALUE* new_list;
 
                 /* Codes_SRS_AMQPVALUE_01_152: [amqpvalue_set_list_item_count shall resize an AMQP list.] */
-                new_list = (AMQP_VALUE*)realloc(value_data->value.list_value.items, list_size * sizeof(AMQP_VALUE));
-                if (new_list == NULL)
+                size_t realloc_size = safe_multiply_size_t(list_size, sizeof(AMQP_VALUE));
+                if (realloc_size == SIZE_MAX ||
+                    (new_list = (AMQP_VALUE*)realloc(value_data->value.list_value.items, realloc_size)) == NULL)
                 {
                     /* Codes_SRS_AMQPVALUE_01_154: [If allocating memory for the list according to the new size fails, then amqpvalue_set_list_item_count shall return a non-zero value, while preserving the existing list contents.] */
-                    LogError("Could not reallocate list memory");
+                    LogError("Could not reallocate list memory, size:%zu", realloc_size);
                     result = MU_FAILURE;
                 }
                 else
@@ -1415,11 +1416,14 @@ int amqpvalue_set_list_item(AMQP_VALUE value, uint32_t index, AMQP_VALUE list_it
             {
                 if (index >= value_data->value.list_value.count)
                 {
-                    AMQP_VALUE* new_list = (AMQP_VALUE*)realloc(value_data->value.list_value.items, ((size_t)index + 1) * sizeof(AMQP_VALUE));
-                    if (new_list == NULL)
+                    AMQP_VALUE* new_list;
+                    size_t realloc_size = safe_add_size_t((size_t)index, 1);
+                    realloc_size = safe_multiply_size_t(realloc_size, sizeof(AMQP_VALUE));
+                    if (realloc_size == SIZE_MAX ||
+                        (new_list = (AMQP_VALUE*)realloc(value_data->value.list_value.items, realloc_size)) == NULL)
                     {
                         /* Codes_SRS_AMQPVALUE_01_170: [When amqpvalue_set_list_item fails due to not being able to clone the item or grow the list, the list shall not be altered.] */
-                        LogError("Could not reallocate list storage");
+                        LogError("Could not reallocate list storage, size:%zu", realloc_size);
                         amqpvalue_destroy(cloned_item);
                         result = MU_FAILURE;
                     }
@@ -1642,13 +1646,16 @@ int amqpvalue_set_map_value(AMQP_VALUE map, AMQP_VALUE key, AMQP_VALUE value)
                     }
                     else
                     {
-                        AMQP_MAP_KEY_VALUE_PAIR* new_pairs = (AMQP_MAP_KEY_VALUE_PAIR*)realloc(value_data->value.map_value.pairs, ((size_t)value_data->value.map_value.pair_count + 1) * sizeof(AMQP_MAP_KEY_VALUE_PAIR));
-                        if (new_pairs == NULL)
+                        AMQP_MAP_KEY_VALUE_PAIR* new_pairs;
+                        size_t realloc_size = safe_add_size_t((size_t)value_data->value.map_value.pair_count, 1);
+                        realloc_size = safe_multiply_size_t(realloc_size, sizeof(AMQP_MAP_KEY_VALUE_PAIR));
+                        if (realloc_size == SIZE_MAX ||
+                            (new_pairs = (AMQP_MAP_KEY_VALUE_PAIR*)realloc(value_data->value.map_value.pairs, realloc_size)) == NULL)
                         {
                             /* Codes_SRS_AMQPVALUE_01_186: [If allocating memory to hold a new key/value pair fails, amqpvalue_set_map_value shall fail and return a non-zero value.] */
                             amqpvalue_destroy(cloned_key);
                             amqpvalue_destroy(cloned_value);
-                            LogError("Could not reallocate memory for map");
+                            LogError("Could not reallocate memory for new_pairs map, size:%zu", realloc_size);
                             result = MU_FAILURE;
                         }
                         else
@@ -1947,13 +1954,16 @@ int amqpvalue_add_array_item(AMQP_VALUE value, AMQP_VALUE array_item_value)
                 }
                 else
                 {
-                    AMQP_VALUE* new_array = (AMQP_VALUE*)realloc(value_data->value.array_value.items, ((size_t)value_data->value.array_value.count + 1) * sizeof(AMQP_VALUE));
-                    if (new_array == NULL)
+                    AMQP_VALUE* new_array;
+                    size_t realloc_size = safe_add_size_t((size_t)value_data->value.array_value.count, 1);
+                    realloc_size = safe_multiply_size_t(realloc_size, sizeof(AMQP_VALUE));
+                    if (realloc_size == SIZE_MAX ||
+                        (new_array = (AMQP_VALUE*)realloc(value_data->value.array_value.items, realloc_size)) == NULL)
                     {
                         /* Codes_SRS_AMQPVALUE_01_423: [ When `amqpvalue_add_array_item` fails due to not being able to clone the item or grow the array, the array shall not be altered. ] */
                         /* Codes_SRS_AMQPVALUE_01_424: [ If growing the array fails, then `amqpvalue_add_array_item` shall fail and return a non-zero value. ] */
                         amqpvalue_destroy(cloned_item);
-                        LogError("Cannot resize array");
+                        LogError("Cannot resize array, size:%zu", realloc_size);
                         result = MU_FAILURE;
                     }
                     else
@@ -5463,6 +5473,7 @@ static int internal_decoder_decode_bytes(INTERNAL_DECODER_DATA* internal_decoder
                             {
                                 AMQP_VALUE described_value;
                                 internal_decoder_destroy(inner_decoder);
+                                internal_decoder_data->inner_decoder = NULL;
 
                                 described_value = REFCOUNT_TYPE_CREATE(AMQP_VALUE_DATA);
                                 if (described_value == NULL)
@@ -6389,10 +6400,11 @@ static int internal_decoder_decode_bytes(INTERNAL_DECODER_DATA* internal_decoder
                             else
                             {
                                 uint32_t i;
-                                internal_decoder_data->decode_to_value->value.list_value.items = (AMQP_VALUE*)calloc(1, (sizeof(AMQP_VALUE) * internal_decoder_data->decode_to_value->value.list_value.count));
-                                if (internal_decoder_data->decode_to_value->value.list_value.items == NULL)
+                                size_t calloc_size = safe_multiply_size_t(sizeof(AMQP_VALUE), internal_decoder_data->decode_to_value->value.list_value.count);
+                                if (calloc_size == SIZE_MAX ||
+                                    (internal_decoder_data->decode_to_value->value.list_value.items = (AMQP_VALUE*)calloc(1, calloc_size)) == NULL)
                                 {
-                                    LogError("Could not allocate memory for decoded list value");
+                                    LogError("Could not allocate memory for decoded list value, size:%zu", calloc_size);
                                     result = MU_FAILURE;
                                 }
                                 else
@@ -6855,10 +6867,11 @@ static int internal_decoder_decode_bytes(INTERNAL_DECODER_DATA* internal_decoder
                             else
                             {
                                 uint32_t i;
-                                internal_decoder_data->decode_to_value->value.array_value.items = (AMQP_VALUE*)calloc(1, (sizeof(AMQP_VALUE) * internal_decoder_data->decode_to_value->value.array_value.count));
-                                if (internal_decoder_data->decode_to_value->value.array_value.items == NULL)
+                                size_t calloc_size = safe_multiply_size_t(sizeof(AMQP_VALUE), internal_decoder_data->decode_to_value->value.array_value.count);
+                                if (calloc_size == SIZE_MAX ||
+                                    (internal_decoder_data->decode_to_value->value.array_value.items = (AMQP_VALUE*)calloc(1, calloc_size)) == NULL)
                                 {
-                                    LogError("Could not allocate memory for array items");
+                                    LogError("Could not allocate memory for array items, size:%zu", calloc_size);
                                     result = MU_FAILURE;
                                 }
                                 else
@@ -6889,10 +6902,11 @@ static int internal_decoder_decode_bytes(INTERNAL_DECODER_DATA* internal_decoder
                                 else
                                 {
                                     uint32_t i;
-                                    internal_decoder_data->decode_to_value->value.array_value.items = (AMQP_VALUE*)calloc(1, (sizeof(AMQP_VALUE) * internal_decoder_data->decode_to_value->value.array_value.count));
-                                    if (internal_decoder_data->decode_to_value->value.array_value.items == NULL)
+                                    size_t calloc_size = safe_multiply_size_t(sizeof(AMQP_VALUE), internal_decoder_data->decode_to_value->value.array_value.count);
+                                    if (calloc_size == SIZE_MAX ||
+                                        (internal_decoder_data->decode_to_value->value.array_value.items = (AMQP_VALUE*)calloc(1, calloc_size)) == NULL)
                                     {
-                                        LogError("Could not allocate memory for array items");
+                                        LogError("Could not allocate memory for array items, size:%zu", calloc_size);
                                         result = MU_FAILURE;
                                     }
                                     else

--- a/src/vendor/azure-uamqp-c/src/connection.c
+++ b/src/vendor/azure-uamqp-c/src/connection.c
@@ -16,6 +16,7 @@
 #include "azure_uamqp_c/amqp_frame_codec.h"
 #include "azure_uamqp_c/amqp_definitions.h"
 #include "azure_uamqp_c/amqpvalue_to_string.h"
+#include "azure_c_shared_utility/safe_math.h"
 
 /* Requirements satisfied by the virtue of implementing the ISO:*/
 /* Codes_S_R_S_CONNECTION_01_088: [Any data appearing beyond the protocol header MUST match the version indicated by the protocol header.] */
@@ -1897,11 +1898,13 @@ ENDPOINT_HANDLE connection_create_endpoint(CONNECTION_HANDLE connection)
                 result->connection = connection;
 
                 /* Codes_S_R_S_CONNECTION_01_197: [The newly created endpoint shall be added to the endpoints list, so that it can be tracked.] */
-                new_endpoints = (ENDPOINT_HANDLE*)realloc(connection->endpoints, sizeof(ENDPOINT_HANDLE) * (connection->endpoint_count + 1));
-                if (new_endpoints == NULL)
+                size_t realloc_size = safe_add_size_t((size_t)connection->endpoint_count, 1);
+                realloc_size = safe_multiply_size_t(realloc_size, sizeof(ENDPOINT_HANDLE));
+                if (realloc_size == SIZE_MAX ||
+                    (new_endpoints = (ENDPOINT_HANDLE*)realloc(connection->endpoints, realloc_size)) == NULL)
                 {
                     /* Tests_S_R_S_CONNECTION_01_198: [If adding the endpoint to the endpoints list tracked by the connection fails, connection_create_endpoint shall fail and return NULL.] */
-                    LogError("Cannot reallocate memory for connection endpoints");
+                    LogError("Cannot reallocate memory for connection endpoints, size:%zu", realloc_size);
                     free(result);
                     result = NULL;
                 }
@@ -1911,7 +1914,15 @@ ENDPOINT_HANDLE connection_create_endpoint(CONNECTION_HANDLE connection)
 
                     if (i < connection->endpoint_count)
                     {
-                        (void)memmove(&connection->endpoints[i + 1], &connection->endpoints[i], sizeof(ENDPOINT_INSTANCE*) * (connection->endpoint_count - i));
+                        size_t memmove_size = safe_multiply_size_t(safe_subtract_size_t(connection->endpoint_count, i), sizeof(ENDPOINT_INSTANCE*));
+                        if (memmove_size != SIZE_MAX)
+                        {
+                            (void)memmove(&connection->endpoints[i + 1], &connection->endpoints[i], memmove_size);
+                        }
+                        else
+                        {
+                            LogError("Cannot memmove endpoints, size:%zu", memmove_size);
+                        }
                     }
 
                     connection->endpoints[i] = result;
@@ -2004,14 +2015,28 @@ void connection_destroy_endpoint(ENDPOINT_HANDLE endpoint)
             else
             {
                 ENDPOINT_HANDLE* new_endpoints;
-
-                if ((connection->endpoint_count - i - 1) > 0)
+                size_t new_count = safe_subtract_size_t(safe_subtract_size_t(connection->endpoint_count, i), 1);
+                if (new_count > 0)
                 {
-                    (void)memmove(connection->endpoints + i, connection->endpoints + i + 1, sizeof(ENDPOINT_HANDLE) * (connection->endpoint_count - i - 1));
+                    size_t memmove_size = safe_multiply_size_t(safe_subtract_size_t(safe_subtract_size_t(connection->endpoint_count, i), 1), sizeof(ENDPOINT_HANDLE));
+                    if (memmove_size != SIZE_MAX)
+                    {
+                        (void)memmove(connection->endpoints + i, connection->endpoints + i + 1, memmove_size);
+                    }
+                    else
+                    {
+                        LogError("Cannot memmove endpoints, size:%zu", memmove_size);
+                    }
                 }
 
-                new_endpoints = (ENDPOINT_HANDLE*)realloc(connection->endpoints, (connection->endpoint_count - 1) * sizeof(ENDPOINT_HANDLE));
-                if (new_endpoints != NULL)
+                size_t realloc_size = safe_subtract_size_t(connection->endpoint_count, 1);
+                realloc_size = safe_multiply_size_t(realloc_size, sizeof(ENDPOINT_HANDLE));
+                if (realloc_size == SIZE_MAX ||
+                    (new_endpoints = (ENDPOINT_HANDLE*)realloc(connection->endpoints, realloc_size)) == NULL)
+                {
+                    LogError("Memory realloc failed, size:%zu", realloc_size);
+                }
+                else
                 {
                     connection->endpoints = new_endpoints;
                 }

--- a/src/vendor/azure-uamqp-c/src/header_detect_io.c
+++ b/src/vendor/azure-uamqp-c/src/header_detect_io.c
@@ -10,6 +10,7 @@
 #include "azure_c_shared_utility/singlylinkedlist.h"
 #include "azure_uamqp_c/header_detect_io.h"
 #include "azure_uamqp_c/server_protocol_io.h"
+#include "azure_c_shared_utility/safe_math.h"
 
 static const unsigned char amqp_header_bytes[] = { 'A', 'M', 'Q', 'P', 0, 1, 0, 0 };
 static const unsigned char sasl_amqp_header_bytes[] = { 'A', 'M', 'Q', 'P', 3, 1, 0, 0 };
@@ -529,9 +530,11 @@ static CONCRETE_IO_HANDLE header_detect_io_create(void* io_create_parameters)
                 else
                 {
                     /* Codes_SRS_HEADER_DETECT_IO_01_009: [ The `header_detect_entries` array shall be copied so that it can be later used when detecting which header was received. ]*/
-                    result->header_detect_entries = (INTERNAL_HEADER_DETECT_ENTRY*)calloc(1, (header_detect_io_config->header_detect_entry_count * sizeof(INTERNAL_HEADER_DETECT_ENTRY)));
-                    if (result->header_detect_entries == NULL)
+                    size_t calloc_size = safe_multiply_size_t(header_detect_io_config->header_detect_entry_count, sizeof(INTERNAL_HEADER_DETECT_ENTRY));
+                    if (calloc_size == SIZE_MAX ||
+                        (result->header_detect_entries = (INTERNAL_HEADER_DETECT_ENTRY*)calloc(1, calloc_size)) == NULL)
                     {
+                        LogError("Could not allocate header_detect_entries, size:%zu", calloc_size);
                         free(result);
                         result = NULL;
                     }
@@ -582,6 +585,7 @@ static CONCRETE_IO_HANDLE header_detect_io_create(void* io_create_parameters)
                                 for (i = 0; i < result->header_detect_entry_count; i++)
                                 {
                                     free(result->header_detect_entries[i].header_bytes);
+                                    result->header_detect_entries[i].header_bytes = NULL;
                                 }
 
                                 free(result->header_detect_entries);
@@ -641,6 +645,7 @@ static void header_detect_io_destroy(CONCRETE_IO_HANDLE header_detect_io)
         {
             /* Codes_SRS_HEADER_DETECT_IO_01_013: [ `header_detect_io_destroy` shall free the memory allocated for the `header_detect_entries`. ]*/
             free(header_detect_io_instance->header_detect_entries[i].header_bytes);
+            header_detect_io_instance->header_detect_entries[i].header_bytes = NULL;
         }
 
         free(header_detect_io_instance->header_detect_entries);

--- a/src/vendor/azure-uamqp-c/src/message.c
+++ b/src/vendor/azure-uamqp-c/src/message.c
@@ -1229,7 +1229,7 @@ int message_set_body_amqp_value(MESSAGE_HANDLE message, AMQP_VALUE body_amqp_val
                 /* Only free the previous value when cloning is succesfull */
                 if (message->body_amqp_value != NULL)
                 {
-                    amqpvalue_destroy(body_amqp_value);
+                    amqpvalue_destroy(message->body_amqp_value);
                 }
 
                 /* Codes_SRS_MESSAGE_01_101: [ `message_set_body_amqp_value` shall set the contents of body as being the AMQP value indicate by `body_amqp_value`. ]*/

--- a/uamqp/__init__.py
+++ b/uamqp/__init__.py
@@ -35,7 +35,7 @@ except (SyntaxError, ImportError):
     pass  # Async not supported.
 
 
-__version__ = "1.6.9"
+__version__ = "1.6.10"
 
 
 _logger = logging.getLogger(__name__)


### PR DESCRIPTION
Pulling upstream changes to vendored uamqp-c. 
Live test run: https://dev.azure.com/azure-sdk/internal/_build/results?buildId=4077788&view=results

Need to investigate the following SB SDK test failures:
- `test_queue_complete_message_on_different_receiver`, which was added to the most recent PR of SB but has not been released
- test_sb_client.py::TestServiceBusClient::test_custom_endpoint_connection_verify_exception with: azure.servicebus.exceptions.ServiceBusError: Handler failed: Authorization timeout..

However, these are not failing locally with the wheels installed, so merging the fix.