### PR TITLE
Explicitly set `long_description_content_type` in `setup.py`

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -262,6 +262,7 @@ setup(
     version=version,
     description='AMQP 1.0 Client Library for Python',
     long_description=readme + '\n\n' + history,
+    long_description_content_type="text/x-rst",
     license='MIT License',
     author='Microsoft Corporation',
     author_email='azpysdkhelp@microsoft.com',


### PR DESCRIPTION
Possibly address failing ESRP? Doubtful tho.