### PR TITLE
Fix clang incompatible function type error.

### DIFF
--- a/src/message_receiver.pyx
+++ b/src/message_receiver.pyx
@@ -120,7 +120,7 @@ cdef class cMessageReceiver(StructBase):
 
 #### Callbacks (context is a MessageReceiver instance)
 
-cdef void on_message_receiver_state_changed(void* context, c_message_receiver.MESSAGE_RECEIVER_STATE_TAG new_state, c_message_receiver.MESSAGE_RECEIVER_STATE_TAG previous_state) noexcept:
+cdef void on_message_receiver_state_changed(const void* context, c_message_receiver.MESSAGE_RECEIVER_STATE_TAG new_state, c_message_receiver.MESSAGE_RECEIVER_STATE_TAG previous_state) noexcept:
     if context != NULL:
         context_pyobj = <PyObject*>context
         if context_pyobj.ob_refcnt == 0: # context is being garbage collected, skip the callback


### PR DESCRIPTION
Fix the error seen in https://github.com/Azure/azure-uamqp-python/issues/386:

```
uamqp/c_uamqp.c:87603:146: error: incompatible function pointer types passing 'void (void *, enum MESSAGE_RECEIVER_STATE_TAG, enum MESSAGE_RECEIVER_STATE_TAG)' to parameter of type 'ON_MESSAGE_RECEIVER_STATE_CHANGED' (aka 'void (*)(const void *, enum MESSAGE_RECEIVER_STATE_TAG, enum MESSAGE_RECEIVER_STATE_TAG)') [-Wincompatible-function-pointer-types]
  __pyx_t_1 = ((struct __pyx_vtabstruct_5uamqp_7c_uamqp_cMessageReceiver *)__pyx_v_receiver->__pyx_vtab)->create(__pyx_v_receiver, __pyx_v_link, __pyx_f_5uamqp_7c_uamqp_on_message_receiver_state_changed, ((void *)__pyx_v_callback_context)); if (unlikely(!__pyx_t_1)) __PYX_ERR(7, 23, __pyx_L1_error)
```

The issue seems to be that `ON_MESSAGE_RECEIVER_STATE_CHANGED` [is defined](https://github.com/Azure/azure-uamqp-python/blob/main/src/vendor/azure-uamqp-c/inc/azure_uamqp_c/message_receiver.h) as:

```
typedef void(*ON_MESSAGE_RECEIVER_STATE_CHANGED)(const void* context, MESSAGE_RECEIVER_STATE new_state, MESSAGE_RECEIVER_STATE previous_state);
```

where `context` is `const void*` and not `void*`. I'm not sure whether `context` really needs to be const since [even in upstream code](https://github.com/Azure/azure-uamqp-c/blob/96d7179f60e558b2c350194ea0061c725377f7e0/src/amqp_management.c#L507) it's cast to something else and its state modified, but we already cast in this function so we can just adopt the same signature.