### PR TITLE
Fix Cmake version

### DIFF
--- a/src/message_receiver.pyx
+++ b/src/message_receiver.pyx
@@ -120,7 +120,7 @@ cdef class cMessageReceiver(StructBase):
 
 #### Callbacks (context is a MessageReceiver instance)
 
-cdef void on_message_receiver_state_changed(void* context, c_message_receiver.MESSAGE_RECEIVER_STATE_TAG new_state, c_message_receiver.MESSAGE_RECEIVER_STATE_TAG previous_state) noexcept:
+cdef void on_message_receiver_state_changed(const void* context, c_message_receiver.MESSAGE_RECEIVER_STATE_TAG new_state, c_message_receiver.MESSAGE_RECEIVER_STATE_TAG previous_state) noexcept:
     if context != NULL:
         context_pyobj = <PyObject*>context
         if context_pyobj.ob_refcnt == 0: # context is being garbage collected, skip the callback

--- a/src/vendor/azure-uamqp-c/deps/azure-macro-utils-c/CMakeLists.txt
+++ b/src/vendor/azure-uamqp-c/deps/azure-macro-utils-c/CMakeLists.txt
@@ -1,7 +1,7 @@
 #Copyright (c) Microsoft. All rights reserved.
 #Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-cmake_minimum_required(VERSION 2.8.11)
+cmake_minimum_required(VERSION 3.5)
 
 if(TARGET azure_macro_utils_c)
     return()

--- a/src/vendor/azure-uamqp-c/deps/umock-c/CMakeLists.txt
+++ b/src/vendor/azure-uamqp-c/deps/umock-c/CMakeLists.txt
@@ -1,7 +1,7 @@
 #Copyright (c) Microsoft. All rights reserved.
 #Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-cmake_minimum_required(VERSION 2.8.11)
+cmake_minimum_required(VERSION 3.5)
 
 if(TARGET umock_c)
     return()


### PR DESCRIPTION
some deps are still looking for `cmake 2.8` which causes issues installing with `python 3.12` on mac. I have update cmake versions and small fix in receiver file which wasn't letting it build